### PR TITLE
Design overhaul · Phase 9 — Phase 2-5 i18n sweep

### DIFF
--- a/docs/superpowers/plans/2026-05-28-design-overhaul-phase-9-i18n-sweep.md
+++ b/docs/superpowers/plans/2026-05-28-design-overhaul-phase-9-i18n-sweep.md
@@ -1,0 +1,638 @@
+# Design Overhaul — Phase 9: Phase 2-5 i18n Sweep Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Sweep every remaining hardcoded English literal out of the Phase 2-5 components into the i18n system. Phase 8 covered Settings; Phase 9 covers everything else built during the overhaul. After this lands, no shipped UI text outside generic shadcn primitives is English-only.
+
+**Architecture:** Mechanical wire-up. Add new namespaces (`queue.*`, `activity.*`, `engine.*`, `attention.*`) and a handful of additions to existing namespaces (`hero.*`, `overview.*`, `inventory.*`, `control.*`, `priorities.*`). Then wire `useI18n()` into each affected component, replacing literals with `t(...)` calls.
+
+**Tech Stack:** No new dependencies. Existing i18n is `src/renderer/shared/i18n.tsx`.
+
+**Spec reference:** [`../specs/2026-05-27-design-overhaul-design.md`](../specs/2026-05-27-design-overhaul-design.md) §11.
+
+**Branch:** `feat/design-overhaul-phase-9-i18n-sweep` (stacked on `feat/design-overhaul-phase-8-i18n-wirings`)
+
+**PR target:** `feat/design-overhaul-phase-8-i18n-wirings` — GitHub auto-retargets.
+
+### Locked decisions
+
+1. **Reuse existing keys aggressively.** Pre-flight audit identified rich existing vocabularies in `overview.*` (35 keys), `inventory.*` (47), `control.*` (90), `priorities.*` (20+). Reuse where the string fits semantically.
+2. **Add 4 new namespaces:** `queue.*`, `activity.*`, `engine.*`, `attention.*`.
+3. **Claim engine wiring is OUT of scope** — the audit confirmed no manual-claim API surface exists. Wiring it requires changes to `useInventory`, `useAppModel`, and the hook→component data flow. Deferred to Phase 10.
+4. **`formatters.ts` time fragments** stay hardcoded in English (e.g. "5m ago"). They're machine-style strings and translating them piecemeal (`{n}{unit} {connector}`) introduces ICU plurals overhead that's not worth it for v1. Add a TODO comment instead.
+5. **Pill values like `live`/`queued`/`paused`/`claimed`** are mono-uppercase status tokens. Treat them as terminology and add proper keys.
+
+### Pre-flight inventory
+
+| File | Strings | Reuse target |
+| --- | --- | --- |
+| `HeroPanel.tsx` | ~12 | new `hero.now*`, `hero.button*` + reuse `overview.claimsReady`, `overview.openDrops` |
+| `QueuePanel.tsx` | ~7 | new `queue.*` namespace |
+| `ActivityPanel.tsx` | ~3 | new `activity.*` namespace |
+| `EnginePanel.tsx` | ~5 | new `engine.*` namespace |
+| `AttentionStrip.tsx` | ~5 | new `attention.*` namespace |
+| `InventoryFilterStrip.tsx` | ~7 | reuse `inventory.filter.*` if exists, else add `inventory.filter.*` keys |
+| `InventoryHeader.tsx` | ~8 | mostly reuse from existing 47 `inventory.*` |
+| `InventoryTable.tsx` | ~5 column labels | reuse `queue.table.*` (queue and inventory tables share column semantics) |
+| `InventoryDrawer.tsx` | ~9 | new `inventory.drawer.*` namespace |
+| `EngineStatusPanel.tsx` | ~5 remaining | new `control.engineStatus.*` keys for `engine status`, `why`, `next`, and DetailRow labels |
+| `ActiveSessionPanel.tsx` | ~8 | new `control.activeSession.*` |
+| `ChannelGridPanel.tsx` | ~4 | new `control.channelGrid.*` |
+| `CampaignsPanel.tsx` | ~5 | new `control.campaignsPanel.*` |
+| `PriorityRow.tsx` | ~4 | reuse `priorities.state.*` |
+| `PriorityList.tsx`, `PriorityHeader.tsx`, `PriorityAddPanel.tsx` | TBD | scan + i18n in T05 |
+
+---
+
+## File Structure
+
+**Modified files (1 + 15-ish components):**
+- `src/renderer/shared/i18n.tsx` — add ~70-80 new keys (EN+DE)
+- `src/renderer/features/overview/{HeroPanel,QueuePanel,ActivityPanel,EnginePanel,AttentionStrip}.tsx`
+- `src/renderer/features/inventory/{InventoryFilterStrip,InventoryHeader,InventoryTable,InventoryDrawer}.tsx`
+- `src/renderer/features/control/{EngineStatusPanel,ActiveSessionPanel,ChannelGridPanel,CampaignsPanel}.tsx`
+- `src/renderer/features/priority/{PriorityRow,PriorityList,PriorityHeader,PriorityAddPanel}.tsx` (scope discovered in T05)
+
+**Untouched:**
+- Settings (Phase 8 already)
+- Phase 1 primitives (no UI text of their own that needs i18n; consumer-supplied labels)
+- Hooks / non-component code
+- formatters.ts time fragments (locked out, see decision 4)
+
+---
+
+## Task 1: Add new i18n keys to i18n.tsx (EN + DE)
+
+**File:** `src/renderer/shared/i18n.tsx`
+
+Add the following to BOTH `en:` and `de:` blocks. Insert near existing namespaces alphabetically where possible.
+
+### EN additions (~75 keys)
+
+```ts
+// hero.now* and hero.button* — HeroPanel
+"hero.nowWatching": "currently watching",
+"hero.statusLive": "LIVE · earning drop",
+"hero.statusIdle": "IDLE",
+"hero.noActiveTarget": "No active target",
+"hero.stat.eta": "eta",
+"hero.stat.channels": "channels",
+"hero.stat.claimsReady": "claims ready",
+"hero.stat.openDrops": "open drops",
+"hero.stat.useInventory": "use inventory",
+"hero.stat.percentComplete": "{pct}% complete",
+"hero.button.claimNow": "claim now",
+"hero.button.pause": "pause",
+"hero.button.switchTarget": "switch target",
+"hero.title.useInventoryToClaim": "Use Inventory view to claim",
+"hero.title.engineNotRunning": "Engine is not running",
+"hero.title.pauseEngine": "Pause the watch engine",
+"hero.title.openPrioritiesToSwitch": "Open Priorities view to switch target",
+"hero.title.wireLater": "Wiring coming in a follow-up phase",
+
+// queue.* — QueuePanel
+"queue.header": "queue · next up",
+"queue.manage": "manage →",
+"queue.empty": "no drops in queue",
+"queue.table.dropGame": "drop · game",
+"queue.table.watched": "watched",
+"queue.table.progress": "progress",
+"queue.table.status": "status",
+"queue.pill.live": "live",
+"queue.pill.queued": "queued",
+
+// activity.* — ActivityPanel
+"activity.header": "recent activity",
+"activity.empty": "no claims yet",
+"activity.claimedPrefix": "Claimed",
+"activity.recently": "recently",
+
+// engine.* — EnginePanel (Overview)
+"engine.header": "engine",
+"engine.row.watchCycle": "watch_cycle",
+"engine.row.lastRefresh": "last_refresh",
+"engine.row.cadence": "cadence",
+"engine.row.uptime": "uptime",
+
+// attention.* — AttentionStrip
+"attention.claimReady": "{count} claim ready",
+"attention.claimsReady": "{count} claims ready",
+"attention.watchError": "watch error",
+"attention.noChannels": "no channels",
+"attention.trackerLabel": "tracker {state}",
+
+// inventory.filter.* — InventoryFilterStrip (and InventoryHeader bits)
+"inventory.filter.aria": "Inventory filter",
+"inventory.filter.all": "all",
+"inventory.filter.priority": "priority",
+"inventory.filter.live": "live",
+"inventory.filter.upcoming": "upcoming",
+"inventory.filter.claimed": "claimed",
+"inventory.filter.notLinked": "not linked",
+"inventory.filter.expired": "expired",
+
+// inventory.header.* — InventoryHeader
+"inventory.header.title": "Inventory",
+"inventory.header.searchPlaceholder": "search drops…",
+"inventory.header.allGames": "All games",
+"inventory.header.refreshTitle": "Refresh inventory",
+"inventory.header.refreshing": "refreshing",
+"inventory.header.refresh": "refresh",
+"inventory.header.linkAccount": "link account",
+"inventory.header.dropsNeedLink.one": "{count} drop needs account-link",
+"inventory.header.dropsNeedLink.other": "{count} drops need account-link",
+"inventory.header.countOf.one": "{shown} of {total} drop",
+"inventory.header.countOf.other": "{shown} of {total} drops",
+
+// inventory.drawer.* — InventoryDrawer
+"inventory.drawer.title": "drop details",
+"inventory.drawer.close": "Close",
+"inventory.drawer.closeAria": "Close drawer",
+"inventory.drawer.progress": "progress",
+"inventory.drawer.blocked": "blocked",
+"inventory.drawer.campaign": "campaign",
+"inventory.drawer.starts": "starts",
+"inventory.drawer.ends": "ends",
+"inventory.drawer.watchedRequired": "watched · required",
+"inventory.drawer.addToPriorities": "add {game} to priorities",
+"inventory.drawer.noActions": "no actions available",
+
+// control.engineStatus.* — EngineStatusPanel hardcoded remnants
+"control.engineStatus.header": "engine status",
+"control.engineStatus.why": "why",
+"control.engineStatus.next": "next",
+"control.engineStatus.detail.target": "target",
+"control.engineStatus.detail.suppression": "suppression",
+"control.engineStatus.detail.cooldowns": "cooldowns",
+"control.engineStatus.detail.allowlist": "allowlist",
+"control.engineStatus.detail.noProgress": "no-progress",
+
+// control.activeSession.* — ActiveSessionPanel
+"control.activeSession.nowWatching": "now watching",
+"control.activeSession.noActiveSession": "no active session",
+"control.activeSession.lastPing": "last ping",
+"control.activeSession.loading": "loading…",
+"control.activeSession.noStream": "no stream",
+"control.activeSession.live": "live",
+"control.activeSession.paused": "paused",
+"control.activeSession.activeDrop": "active drop",
+"control.activeSession.watchedRequiredEta": "{watched} watched · {required} required · eta {eta}",
+"control.activeSession.watchedRequired": "{watched} watched · {required} required",
+"control.activeSession.noFarmable": "no farmable drop on this channel",
+"control.activeSession.engineIdle": "engine idle",
+"control.activeSession.viewers": "viewers",
+
+// control.channelGrid.* — ChannelGridPanel
+"control.channelGrid.header": "live channels",
+"control.channelGrid.refreshTitle": "Refresh channel list",
+"control.channelGrid.refresh": "refresh",
+"control.channelGrid.noTarget": "select a target game in Priorities to see live channels",
+"control.channelGrid.watchingPill": "watching",
+
+// control.campaignsPanel.* — CampaignsPanel
+"control.campaignsPanel.empty": "no active campaigns",
+"control.campaignsPanel.header": "campaigns",
+"control.campaignsPanel.status.claimed": "claimed",
+"control.campaignsPanel.status.blocked": "blocked",
+"control.campaignsPanel.status.live": "live",
+"control.campaignsPanel.status.queued": "queued",
+"control.campaignsPanel.footerTotal": "total",
+"control.campaignsPanel.footerDrops.one": "{count} drop",
+"control.campaignsPanel.footerDrops.other": "{count} drops",
+
+// priority row reuses existing priorities.state.* — no new keys needed there
+// However add aria labels:
+"priorities.row.dragAria": "Drag {game}",
+"priorities.row.removeAria": "Remove {game}",
+```
+
+### DE additions (matching ~75 keys)
+
+```ts
+"hero.nowWatching": "läuft gerade",
+"hero.statusLive": "LIVE · sammelt Drop",
+"hero.statusIdle": "PAUSE",
+"hero.noActiveTarget": "Kein aktives Ziel",
+"hero.stat.eta": "eta",
+"hero.stat.channels": "channels",
+"hero.stat.claimsReady": "claims bereit",
+"hero.stat.openDrops": "offene drops",
+"hero.stat.useInventory": "inventar nutzen",
+"hero.stat.percentComplete": "{pct}% fertig",
+"hero.button.claimNow": "jetzt claimen",
+"hero.button.pause": "pause",
+"hero.button.switchTarget": "ziel wechseln",
+"hero.title.useInventoryToClaim": "Im Inventar claimen",
+"hero.title.engineNotRunning": "Engine läuft nicht",
+"hero.title.pauseEngine": "Watch-Engine pausieren",
+"hero.title.openPrioritiesToSwitch": "Prioritäten-Ansicht öffnen, um Ziel zu wechseln",
+"hero.title.wireLater": "Wird in einer späteren Phase verkabelt",
+
+"queue.header": "queue · als nächstes",
+"queue.manage": "verwalten →",
+"queue.empty": "keine drops in der queue",
+"queue.table.dropGame": "drop · spiel",
+"queue.table.watched": "geschaut",
+"queue.table.progress": "fortschritt",
+"queue.table.status": "status",
+"queue.pill.live": "live",
+"queue.pill.queued": "queue",
+
+"activity.header": "letzte aktivität",
+"activity.empty": "noch keine claims",
+"activity.claimedPrefix": "Eingesammelt:",
+"activity.recently": "vor kurzem",
+
+"engine.header": "engine",
+"engine.row.watchCycle": "watch_cycle",
+"engine.row.lastRefresh": "last_refresh",
+"engine.row.cadence": "cadence",
+"engine.row.uptime": "uptime",
+
+"attention.claimReady": "{count} claim bereit",
+"attention.claimsReady": "{count} claims bereit",
+"attention.watchError": "watch-fehler",
+"attention.noChannels": "keine channels",
+"attention.trackerLabel": "tracker {state}",
+
+"inventory.filter.aria": "Inventar-Filter",
+"inventory.filter.all": "alle",
+"inventory.filter.priority": "priorität",
+"inventory.filter.live": "live",
+"inventory.filter.upcoming": "kommend",
+"inventory.filter.claimed": "geclaimt",
+"inventory.filter.notLinked": "nicht verknüpft",
+"inventory.filter.expired": "abgelaufen",
+
+"inventory.header.title": "Inventar",
+"inventory.header.searchPlaceholder": "drops suchen…",
+"inventory.header.allGames": "Alle Spiele",
+"inventory.header.refreshTitle": "Inventar aktualisieren",
+"inventory.header.refreshing": "lade",
+"inventory.header.refresh": "aktualisieren",
+"inventory.header.linkAccount": "account verknüpfen",
+"inventory.header.dropsNeedLink.one": "{count} drop braucht Account-Link",
+"inventory.header.dropsNeedLink.other": "{count} drops brauchen Account-Link",
+"inventory.header.countOf.one": "{shown} von {total} drop",
+"inventory.header.countOf.other": "{shown} von {total} drops",
+
+"inventory.drawer.title": "drop-details",
+"inventory.drawer.close": "Schließen",
+"inventory.drawer.closeAria": "Drawer schließen",
+"inventory.drawer.progress": "fortschritt",
+"inventory.drawer.blocked": "blockiert",
+"inventory.drawer.campaign": "kampagne",
+"inventory.drawer.starts": "start",
+"inventory.drawer.ends": "ende",
+"inventory.drawer.watchedRequired": "geschaut · benötigt",
+"inventory.drawer.addToPriorities": "{game} zu Prioritäten",
+"inventory.drawer.noActions": "keine Aktionen verfügbar",
+
+"control.engineStatus.header": "engine-status",
+"control.engineStatus.why": "warum",
+"control.engineStatus.next": "nächstes",
+"control.engineStatus.detail.target": "ziel",
+"control.engineStatus.detail.suppression": "unterdrückt",
+"control.engineStatus.detail.cooldowns": "cooldowns",
+"control.engineStatus.detail.allowlist": "allowlist",
+"control.engineStatus.detail.noProgress": "kein fortschritt",
+
+"control.activeSession.nowWatching": "läuft gerade",
+"control.activeSession.noActiveSession": "keine aktive session",
+"control.activeSession.lastPing": "letzter ping",
+"control.activeSession.loading": "lade…",
+"control.activeSession.noStream": "kein stream",
+"control.activeSession.live": "live",
+"control.activeSession.paused": "pausiert",
+"control.activeSession.activeDrop": "aktiver drop",
+"control.activeSession.watchedRequiredEta": "{watched} geschaut · {required} benötigt · eta {eta}",
+"control.activeSession.watchedRequired": "{watched} geschaut · {required} benötigt",
+"control.activeSession.noFarmable": "kein farmbarer drop auf diesem channel",
+"control.activeSession.engineIdle": "engine im leerlauf",
+"control.activeSession.viewers": "viewer",
+
+"control.channelGrid.header": "live channels",
+"control.channelGrid.refreshTitle": "Channel-Liste aktualisieren",
+"control.channelGrid.refresh": "aktualisieren",
+"control.channelGrid.noTarget": "wähle ein Ziel-Spiel in Prioritäten, um live channels zu sehen",
+"control.channelGrid.watchingPill": "watching",
+
+"control.campaignsPanel.empty": "keine aktiven Kampagnen",
+"control.campaignsPanel.header": "kampagnen",
+"control.campaignsPanel.status.claimed": "geclaimt",
+"control.campaignsPanel.status.blocked": "blockiert",
+"control.campaignsPanel.status.live": "live",
+"control.campaignsPanel.status.queued": "queue",
+"control.campaignsPanel.footerTotal": "gesamt",
+"control.campaignsPanel.footerDrops.one": "{count} drop",
+"control.campaignsPanel.footerDrops.other": "{count} drops",
+
+"priorities.row.dragAria": "{game} ziehen",
+"priorities.row.removeAria": "{game} entfernen",
+```
+
+### Steps
+
+- [ ] **Step 1:** Add all EN keys to the `en:` block at a sensible insertion point (alphabetically grouped or at the end of `settings.*` block ~line 700 where Phase 8 added its keys).
+- [ ] **Step 2:** Add all matching DE keys to the `de:` block at the same relative position.
+- [ ] **Step 3:** Verify counts: `grep -c '"queue\.' src/renderer/shared/i18n.tsx` → 18 (9 × 2); `grep -c '"activity\.' src/renderer/shared/i18n.tsx` → 8; `grep -c '"attention\.' src/renderer/shared/i18n.tsx` → 10; `grep -c '"engine\.' src/renderer/shared/i18n.tsx` → 10.
+- [ ] **Step 4:** TSC + tests.
+- [ ] **Step 5:** Commit:
+  ```
+  feat(i18n): add ~75 keys for Phase 2-5 components (EN + DE)
+
+  Adds queue.*, activity.*, engine.*, attention.* (4 new namespaces),
+  hero.now*/hero.button*/hero.stat*/hero.title* additions, inventory.filter.*,
+  inventory.header.*, inventory.drawer.* additions, control.engineStatus.*,
+  control.activeSession.*, control.channelGrid.*, control.campaignsPanel.*
+  additions, and priorities.row.*Aria.
+
+  Prep for Phase 9 T02-T05 i18n wire-up across all Phase 2-5 components.
+  ```
+
+---
+
+## Task 2: Wire Overview features (HeroPanel + QueuePanel + ActivityPanel + EnginePanel + AttentionStrip)
+
+For each file: add `useI18n` import, call `const { t } = useI18n();`, replace listed hardcoded strings with `t(...)` calls.
+
+### HeroPanel.tsx mappings
+
+| Hardcoded | Key |
+| --- | --- |
+| `"currently watching"` | `hero.nowWatching` |
+| `"LIVE · earning drop"` | `hero.statusLive` |
+| `"IDLE"` | `hero.statusIdle` |
+| `"No active target"` (default for title) | `hero.noActiveTarget` |
+| `"eta"` (stat label) | `hero.stat.eta` |
+| `"channels"` | `hero.stat.channels` |
+| `"claims ready"` | `hero.stat.claimsReady` |
+| `"open drops"` | `hero.stat.openDrops` |
+| `"use inventory"` sub | `hero.stat.useInventory` |
+| `${progressPct}% complete` | use `t("hero.stat.percentComplete", { pct: progressPct })` |
+| `"claim now"` | `hero.button.claimNow` |
+| `"pause"` | `hero.button.pause` |
+| `"switch target"` | `hero.button.switchTarget` |
+| title `"Use Inventory view to claim"` | `hero.title.useInventoryToClaim` |
+| title `"Engine is not running"` | `hero.title.engineNotRunning` |
+| title `"Pause the watch engine"` | `hero.title.pauseEngine` |
+| title `"Open Priorities view to switch target"` | `hero.title.openPrioritiesToSwitch` |
+| title `"Phase 5 will wire this"` | `hero.title.wireLater` |
+
+### QueuePanel.tsx mappings
+
+| Hardcoded | Key |
+| --- | --- |
+| `"queue · next up"` | `queue.header` |
+| `"manage →"` | `queue.manage` |
+| `"no drops in queue"` | `queue.empty` |
+| `"drop · game"` | `queue.table.dropGame` |
+| `"watched"` | `queue.table.watched` |
+| `"progress"` | `queue.table.progress` |
+| `"status"` | `queue.table.status` |
+| status `"live"` in pill | `queue.pill.live` |
+| status `"queued"` in pill | `queue.pill.queued` |
+
+### ActivityPanel.tsx mappings
+
+| Hardcoded | Key |
+| --- | --- |
+| `"recent activity"` | `activity.header` |
+| `"no claims yet"` | `activity.empty` |
+| `"Claimed"` (JSX prefix) | `activity.claimedPrefix` |
+| `"recently"` | `activity.recently` |
+
+### EnginePanel.tsx mappings
+
+| Hardcoded | Key |
+| --- | --- |
+| `"engine"` (SectionLabel) | `engine.header` |
+| `"watch_cycle"` row key | `engine.row.watchCycle` |
+| `"last_refresh"` row key | `engine.row.lastRefresh` |
+| `"cadence"` row key | `engine.row.cadence` |
+| `"uptime"` row key | `engine.row.uptime` |
+
+### AttentionStrip.tsx mappings
+
+| Hardcoded | Key |
+| --- | --- |
+| `{count} claim ready` / `{count} claims ready` | use `t("attention.claimReady"|"attention.claimsReady", { count })` with count==1 picking single |
+| `"watch error"` | `attention.watchError` |
+| `"no channels"` | `attention.noChannels` |
+| `tracker {connectionState}` | `t("attention.trackerLabel", { state: connectionState })` |
+
+### Steps
+
+- [ ] Wire each of the 5 files (add useI18n, replace strings).
+- [ ] TSC + tests + lint.
+- [ ] Branch check + ONE commit per task batch:
+  ```
+  feat(overview): wire useI18n into HeroPanel/QueuePanel/ActivityPanel/EnginePanel/AttentionStrip
+
+  Replaces ~32 hardcoded English literals with t() calls using
+  hero.now*/button*/stat*/title*, queue.*, activity.*, engine.*,
+  attention.* keys added in T01.
+  ```
+
+---
+
+## Task 3: Wire Inventory features (InventoryFilterStrip + InventoryHeader + InventoryTable + InventoryDrawer)
+
+### InventoryFilterStrip.tsx mappings
+
+The 7 `CHIP_DEFS` labels map to `inventory.filter.all`, `inventory.filter.priority`, `inventory.filter.live`, `inventory.filter.upcoming`, `inventory.filter.claimed`, `inventory.filter.notLinked`, `inventory.filter.expired`. Move `CHIP_DEFS` inside the component body so it can use `t()` — or build the array via `useMemo([t])`. The `aria-label="Inventory filter"` → `t("inventory.filter.aria")`.
+
+### InventoryHeader.tsx mappings
+
+| Hardcoded | Key |
+| --- | --- |
+| `"Inventory"` | `inventory.header.title` |
+| `"search drops…"` placeholder | `inventory.header.searchPlaceholder` |
+| `"All games"` | `inventory.header.allGames` |
+| `"Refresh inventory"` title | `inventory.header.refreshTitle` |
+| `"refreshing"` | `inventory.header.refreshing` |
+| `"refresh"` | `inventory.header.refresh` |
+| `"link account"` | `inventory.header.linkAccount` |
+| `{n} drop{s} need account-link` | use plural pair `inventory.header.dropsNeedLink.{one|other}` |
+| `{shown} of {total} drops` | use plural pair `inventory.header.countOf.{one|other}` |
+
+For plurals: pick `.one` when count === 1, else `.other`. Templates use `{count}` / `{shown}` / `{total}` placeholders.
+
+### InventoryTable.tsx mappings
+
+Column header strings (`"drop · game"`, `"watched"`, `"progress"`, `"status"`) reuse the `queue.table.*` keys (intentional sharing).
+
+### InventoryDrawer.tsx mappings
+
+| Hardcoded | Key |
+| --- | --- |
+| `"drop details"` (SectionLabel) | `inventory.drawer.title` |
+| `"Close"` aria | `inventory.drawer.close` |
+| `"Close drawer"` aria | `inventory.drawer.closeAria` |
+| `"progress"` | `inventory.drawer.progress` |
+| `"blocked"` | `inventory.drawer.blocked` |
+| `"campaign"` | `inventory.drawer.campaign` |
+| `"starts"` | `inventory.drawer.starts` |
+| `"ends"` | `inventory.drawer.ends` |
+| `"watched · required"` | `inventory.drawer.watchedRequired` |
+| `add {game} to priorities` | `t("inventory.drawer.addToPriorities", { game })` |
+| `"no actions available"` | `inventory.drawer.noActions` |
+
+### Steps
+
+- [ ] Wire each file. Commit:
+  ```
+  feat(inventory): wire useI18n into FilterStrip/Header/Table/Drawer
+
+  Replaces ~30 hardcoded English literals (filter chip labels, header
+  controls, drawer details) with t() calls using new inventory.filter.*,
+  inventory.header.*, inventory.drawer.* keys plus shared queue.table.*
+  for column headers.
+  ```
+
+---
+
+## Task 4: Wire Control features (EngineStatusPanel + ActiveSessionPanel + ChannelGridPanel + CampaignsPanel)
+
+### EngineStatusPanel.tsx mappings
+
+EngineStatusPanel already imports `useI18n`. Remaining hardcoded strings:
+
+| Hardcoded | Key |
+| --- | --- |
+| `"engine status"` (SectionLabel inline) | `control.engineStatus.header` |
+| `"why"` row label | `control.engineStatus.why` |
+| `"next"` row label | `control.engineStatus.next` |
+| DetailRow label `"target"` | `control.engineStatus.detail.target` |
+| DetailRow label `"suppression"` | `control.engineStatus.detail.suppression` |
+| DetailRow label `"cooldowns"` | `control.engineStatus.detail.cooldowns` |
+| DetailRow label `"allowlist"` | `control.engineStatus.detail.allowlist` |
+| DetailRow label `"no-progress"` | `control.engineStatus.detail.noProgress` |
+
+### ActiveSessionPanel.tsx mappings
+
+| Hardcoded | Key |
+| --- | --- |
+| `"now watching"` | `control.activeSession.nowWatching` |
+| `"no active session"` | `control.activeSession.noActiveSession` |
+| `"last ping · {formatRelative}"` | use `t("control.activeSession.lastPing")` + ` · ` + `formatRelative(lastWatchOk)` (keep the time fragment hardcoded) |
+| `"loading…"` | `control.activeSession.loading` |
+| `"no stream"` | `control.activeSession.noStream` |
+| pill `"live"` | `control.activeSession.live` |
+| pill `"paused"` | `control.activeSession.paused` |
+| `"active drop"` SectionLabel | `control.activeSession.activeDrop` |
+| `{watched} watched · {required} required · eta {eta}` line | `control.activeSession.watchedRequiredEta` with placeholders |
+| same without eta | `control.activeSession.watchedRequired` |
+| `"no farmable drop on this channel"` | `control.activeSession.noFarmable` |
+| `"engine idle"` | `control.activeSession.engineIdle` |
+| `"viewers"` | `control.activeSession.viewers` |
+
+### ChannelGridPanel.tsx mappings
+
+| Hardcoded | Key |
+| --- | --- |
+| `"live channels"` SectionLabel | `control.channelGrid.header` |
+| `"Refresh channel list"` title | `control.channelGrid.refreshTitle` |
+| `"refresh"` button | `control.channelGrid.refresh` |
+| `"select a target game in Priorities to see live channels"` | `control.channelGrid.noTarget` |
+| `"watching"` pill | `control.channelGrid.watchingPill` |
+
+### CampaignsPanel.tsx mappings
+
+| Hardcoded | Key |
+| --- | --- |
+| `"no active campaigns"` | `control.campaignsPanel.empty` |
+| `"campaigns"` SectionLabel | `control.campaignsPanel.header` |
+| status `"claimed"` | `control.campaignsPanel.status.claimed` |
+| status `"blocked"` | `control.campaignsPanel.status.blocked` |
+| status `"live"` | `control.campaignsPanel.status.live` |
+| status `"queued"` | `control.campaignsPanel.status.queued` |
+| `"total"` footer | `control.campaignsPanel.footerTotal` |
+| `{count} drops` footer | `t("control.campaignsPanel.footerDrops.{one|other}", { count })` |
+
+### Steps
+
+- [ ] Wire each file. Commit:
+  ```
+  feat(control): wire useI18n into EngineStatusPanel/ActiveSessionPanel/ChannelGridPanel/CampaignsPanel
+
+  Replaces remaining hardcoded English literals with t() calls using
+  new control.engineStatus.*, control.activeSession.*, control.channelGrid.*,
+  control.campaignsPanel.* keys.
+  ```
+
+---
+
+## Task 5: Wire Priority features
+
+Start by scanning the priority feature folder to find ALL components:
+```bash
+ls src/renderer/features/priority/
+```
+
+For each component with hardcoded English, wire `useI18n` and use `priorities.state.*` keys for the state labels (`watching`, `target`, `live`, `idle`) and the new `priorities.row.dragAria` / `priorities.row.removeAria` for the aria-labels. For any other hardcoded strings discovered, add new keys to i18n.tsx in a Step-1 amendment commit if needed.
+
+### PriorityRow.tsx mappings (known)
+
+| Hardcoded | Key |
+| --- | --- |
+| `STATE_LABEL.watching` value `"watching"` | `priorities.state.watching` (existing) |
+| `STATE_LABEL.target` value `"target"` | `priorities.state.target` (existing) |
+| `STATE_LABEL.live` value `"live"` | `priorities.state.live` (existing) |
+| `STATE_LABEL.idle` value `"idle"` | `priorities.state.idle` (existing) |
+| `aria-label={\`Drag ${game}\`}` | `t("priorities.row.dragAria", { game })` |
+| `aria-label={\`Remove ${game}\`}` | `t("priorities.row.removeAria", { game })` |
+
+### Steps
+
+- [ ] Scan priority components, build mapping for each. If new strings discovered, add keys to i18n.tsx (separate small commit before the wire-up commit). The mappings above are confirmed; others depend on what's there.
+- [ ] Wire and commit:
+  ```
+  feat(priority): wire useI18n into priority components
+
+  Reuses priorities.state.* for state labels and adds aria templates
+  via priorities.row.dragAria/removeAria. Any per-file discoveries
+  noted in the commit body.
+  ```
+
+---
+
+## Task 6: Verify end-to-end
+
+- [ ] Full check:
+  ```bash
+  npm run lint 2>&1 | tail -10   # 0 errors
+  npx tsc --noEmit -p tsconfig.json 2>&1 | wc -l   # baseline ~21
+  npm test 2>&1 | tail -5   # 214/214
+  npm run build 2>&1 | tail -10   # clean
+  ```
+- [ ] Sanity grep — count remaining hardcoded English in scanned files. Run from repo root:
+  ```bash
+  grep -rE '\blabel="(?!.*\{)[A-Z]' src/renderer/features/{overview,inventory,control,priority}/ --include="*.tsx" | grep -v '\.test\.' | head -20
+  ```
+  Expected: very few hits, all explicable (e.g., props passed through to primitives).
+- [ ] Branch summary:
+  ```bash
+  git log --oneline feat/design-overhaul-phase-8-i18n-wirings..HEAD
+  ```
+  Expected ~6 commits.
+
+## Report
+
+Per task: SHA. Final: lint/tsc/test/build + sanity grep summary.
+
+---
+
+## Out of Scope
+
+- HeroPanel claim-now button wiring — separate phase
+- formatters.ts time fragments — locked out (see decision 4); add TODO comment if not already there
+- Light-mode visual polish — separate phase
+- `--dp-*` token rename — separate phase
+- Any new copy / UX changes — this is purely an i18n sweep
+
+## Open items
+
+- Some component files import `useI18n` already but only use it for ONE string (e.g., ActiveSessionPanel). Task 4 finalizes them. After this PR, every Phase 2-5 component is either fully i18n'd or doesn't need it.
+- The `formatters.ts` "5m ago"/"2h ago" pattern could later be ICU-pluralized for proper DE rendering. Leave as-is.
+- DE translations are best-effort. Native German speakers may want to refine some (e.g., "läuft gerade" vs "schaut gerade"). Improvements welcome in a follow-up.

--- a/src/renderer/features/control/ActiveSessionPanel.tsx
+++ b/src/renderer/features/control/ActiveSessionPanel.tsx
@@ -48,10 +48,10 @@ export function ActiveSessionPanel({
   return (
     <div className="rounded-[var(--dp-radius-lg)] border border-[color:var(--dp-border)] bg-[color:var(--dp-bg-elevated)]">
       <div className="flex items-center justify-between px-5 py-4 border-b border-[color:var(--dp-border-soft)]">
-        <SectionLabel inline>{isWatching ? "now watching" : "no active session"}</SectionLabel>
+        <SectionLabel inline>{isWatching ? t("control.activeSession.nowWatching") : t("control.activeSession.noActiveSession")}</SectionLabel>
         {lastWatchOk && (
           <div className="font-mono text-[10px] text-[color:var(--dp-text-dimmer)]">
-            last ping · {formatRelative(lastWatchOk)}
+            {t("control.activeSession.lastPing")} · {formatRelative(lastWatchOk)}
           </div>
         )}
       </div>
@@ -69,7 +69,7 @@ export function ActiveSessionPanel({
               />
             ) : (
               <div className="flex items-center justify-center h-full font-mono text-[10px] text-[color:var(--dp-text-dimmer)]">
-                {isWatching ? "loading…" : "no stream"}
+                {isWatching ? t("control.activeSession.loading") : t("control.activeSession.noStream")}
               </div>
             )}
           </div>
@@ -89,16 +89,16 @@ export function ActiveSessionPanel({
             {isWatching ? (
               <div className="flex items-center gap-2">
                 <Pill tone="accent" dot>
-                  live
+                  {t("control.activeSession.live")}
                 </Pill>
                 {viewers > 0 && (
                   <span className="font-mono text-[11px] text-[color:var(--dp-text-dim)] tabular-nums">
-                    {viewers.toLocaleString()} viewers
+                    {viewers.toLocaleString()} {t("control.activeSession.viewers")}
                   </span>
                 )}
               </div>
             ) : (
-              <Pill tone="dim">paused</Pill>
+              <Pill tone="dim">{t("control.activeSession.paused")}</Pill>
             )}
             {activeLoginMismatch && (
               <div className="mt-2 font-mono text-[10px] text-[color:var(--dp-signal-warn)]">
@@ -111,7 +111,7 @@ export function ActiveSessionPanel({
         {/* Active drop */}
         {activeDropTitle ? (
           <div className="border-t border-[color:var(--dp-border-soft)] pt-4">
-            <SectionLabel>active drop</SectionLabel>
+            <SectionLabel>{t("control.activeSession.activeDrop")}</SectionLabel>
             <div className="mt-2 text-[15px] font-medium text-[color:var(--dp-text)] mb-2">
               {activeDropTitle}
             </div>
@@ -131,15 +131,21 @@ export function ActiveSessionPanel({
               </span>
             </div>
             <div className="font-mono text-[10px] text-[color:var(--dp-text-dimmer)]">
-              {formatHourMinute(activeDropEarnedMinutes)} watched ·{" "}
-              {activeDropRequiredMinutes > 0 ? formatHourMinute(activeDropRequiredMinutes) : "—"}{" "}
-              required
-              {activeEtaText && ` · eta ${activeEtaText}`}
+              {activeEtaText
+                ? t("control.activeSession.watchedRequiredEta", {
+                    watched: formatHourMinute(activeDropEarnedMinutes),
+                    required: activeDropRequiredMinutes > 0 ? formatHourMinute(activeDropRequiredMinutes) : "—",
+                    eta: activeEtaText,
+                  })
+                : t("control.activeSession.watchedRequired", {
+                    watched: formatHourMinute(activeDropEarnedMinutes),
+                    required: activeDropRequiredMinutes > 0 ? formatHourMinute(activeDropRequiredMinutes) : "—",
+                  })}
             </div>
           </div>
         ) : (
           <div className="border-t border-[color:var(--dp-border-soft)] pt-4 font-mono text-[11px] text-[color:var(--dp-text-dimmer)]">
-            {isWatching ? "no farmable drop on this channel" : "engine idle"}
+            {isWatching ? t("control.activeSession.noFarmable") : t("control.activeSession.engineIdle")}
           </div>
         )}
       </div>

--- a/src/renderer/features/control/CampaignsPanel.tsx
+++ b/src/renderer/features/control/CampaignsPanel.tsx
@@ -42,7 +42,7 @@ export function CampaignsPanel({
     return (
       <div className="rounded-[var(--dp-radius-lg)] border border-[color:var(--dp-border)] bg-[color:var(--dp-bg-elevated)] px-5 py-8 text-center">
         <p className="font-mono text-[11px] text-[color:var(--dp-text-dimmer)]">
-          no active campaigns
+          {t("control.campaignsPanel.empty")}
         </p>
       </div>
     );
@@ -53,7 +53,7 @@ export function CampaignsPanel({
   return (
     <div className="rounded-[var(--dp-radius-lg)] border border-[color:var(--dp-border)] bg-[color:var(--dp-bg-elevated)]">
       <div className="flex items-center gap-3 px-5 py-4 border-b border-[color:var(--dp-border-soft)]">
-        <SectionLabel inline>campaigns</SectionLabel>
+        <SectionLabel inline>{t("control.campaignsPanel.header")}</SectionLabel>
         <span className="font-mono text-[10px] text-[color:var(--dp-text-dimmer)]">
           · {groups.length}
         </span>
@@ -109,12 +109,12 @@ export function CampaignsPanel({
                 : "accent"
               : "dim";
           const statusText = isClaimed
-            ? "claimed"
+            ? t("control.campaignsPanel.status.claimed")
             : drop.status === "progress"
               ? drop.blocked
-                ? "blocked"
-                : "live"
-              : "queued";
+                ? t("control.campaignsPanel.status.blocked")
+                : t("control.campaignsPanel.status.live")
+              : t("control.campaignsPanel.status.queued");
 
           return (
             <li
@@ -159,10 +159,10 @@ export function CampaignsPanel({
       <div className="px-5 py-3 border-t border-[color:var(--dp-border-soft)] flex items-center justify-between font-mono text-[10px] text-[color:var(--dp-text-dimmer)]">
         <span>
           {formatHourMinute(activeGroup.totalEarned)} /{" "}
-          {formatHourMinute(activeGroup.totalRequired)} total
+          {formatHourMinute(activeGroup.totalRequired)} {t("control.campaignsPanel.footerTotal")}
         </span>
         <span>
-          {activeGroup.drops.length} drop{activeGroup.drops.length === 1 ? "" : "s"}
+          {t(activeGroup.drops.length === 1 ? "control.campaignsPanel.footerDrops.one" : "control.campaignsPanel.footerDrops.other", { count: activeGroup.drops.length })}
         </span>
       </div>
     </div>

--- a/src/renderer/features/control/ChannelGridPanel.tsx
+++ b/src/renderer/features/control/ChannelGridPanel.tsx
@@ -47,7 +47,7 @@ export function ChannelGridPanel({
     <div className="rounded-[var(--dp-radius-lg)] border border-[color:var(--dp-border)] bg-[color:var(--dp-bg-elevated)]">
       <div className="flex items-center justify-between px-5 py-4 border-b border-[color:var(--dp-border-soft)]">
         <div className="flex items-center gap-3">
-          <SectionLabel inline>live channels</SectionLabel>
+          <SectionLabel inline>{t("control.channelGrid.header")}</SectionLabel>
           <span className="font-mono text-[10px] text-[color:var(--dp-text-dimmer)]">
             · {channels.filter((c) => !c.exiting).length}
           </span>
@@ -57,14 +57,14 @@ export function ChannelGridPanel({
           size="dp-sm"
           onClick={onRefresh}
           disabled={refreshDisabled}
-          title="Refresh channel list"
+          title={t("control.channelGrid.refreshTitle")}
         >
           <RotateCw
             size={11}
             strokeWidth={1.8}
             className={channelsRefreshing ? "animate-spin" : undefined}
           />
-          refresh
+          {t("control.channelGrid.refresh")}
         </Button>
       </div>
 
@@ -92,7 +92,7 @@ export function ChannelGridPanel({
           <div className="text-center py-8 font-mono text-[11px] text-[color:var(--dp-text-dimmer)]">
             {targetGame
               ? t("control.channelsEmpty")
-              : "select a target game in Priorities to see live channels"}
+              : t("control.channelGrid.noTarget")}
           </div>
         ) : (
           <ul
@@ -148,7 +148,7 @@ export function ChannelGridPanel({
                       {isWatching && (
                         <span className="absolute top-1 left-1">
                           <Pill tone="accent" dot>
-                            watching
+                            {t("control.channelGrid.watchingPill")}
                           </Pill>
                         </span>
                       )}

--- a/src/renderer/features/control/EngineStatusPanel.tsx
+++ b/src/renderer/features/control/EngineStatusPanel.tsx
@@ -132,7 +132,7 @@ export function EngineStatusPanel(props: EngineStatusPanelProps) {
             }}
           />
           <div className="flex flex-col items-start min-w-0">
-            <SectionLabel inline>engine status</SectionLabel>
+            <SectionLabel inline>{t("control.engineStatus.header")}</SectionLabel>
             <div className={cn("text-[15px] font-medium mt-1 truncate", TONE_TEXT[tone])}>
               {label}
             </div>
@@ -151,11 +151,11 @@ export function EngineStatusPanel(props: EngineStatusPanelProps) {
       <div className="px-5 pb-4">
         <div className="grid gap-1.5">
           <div className="flex gap-3 font-mono text-[11px]">
-            <span className="text-[color:var(--dp-text-dimmer)] w-12 flex-shrink-0">why</span>
+            <span className="text-[color:var(--dp-text-dimmer)] w-12 flex-shrink-0">{t("control.engineStatus.why")}</span>
             <span className="text-[color:var(--dp-text-dim)] flex-1">{details.why}</span>
           </div>
           <div className="flex gap-3 font-mono text-[11px]">
-            <span className="text-[color:var(--dp-text-dimmer)] w-12 flex-shrink-0">next</span>
+            <span className="text-[color:var(--dp-text-dimmer)] w-12 flex-shrink-0">{t("control.engineStatus.next")}</span>
             <span className="text-[color:var(--dp-text-dim)] flex-1">{details.next}</span>
           </div>
         </div>
@@ -163,12 +163,12 @@ export function EngineStatusPanel(props: EngineStatusPanelProps) {
 
       {expanded && (
         <div id={detailsId} className="border-t border-[color:var(--dp-border-soft)] px-5 py-4 grid gap-2">
-          <DetailRow label="target" value={targetText} />
-          <DetailRow label="suppression" value={suppressionText} />
-          <DetailRow label="cooldowns" value={cooldownText} />
-          <DetailRow label="allowlist" value={allowlistText} sub={channelsText} />
+          <DetailRow label={t("control.engineStatus.detail.target")} value={targetText} />
+          <DetailRow label={t("control.engineStatus.detail.suppression")} value={suppressionText} />
+          <DetailRow label={t("control.engineStatus.detail.cooldowns")} value={cooldownText} />
+          <DetailRow label={t("control.engineStatus.detail.allowlist")} value={allowlistText} sub={channelsText} />
           <DetailRow label={t("control.tracker.label")} value={trackerText} tone={trackerTone} />
-          {noProgressText && <DetailRow label="no-progress" value={noProgressText} tone="warn" />}
+          {noProgressText && <DetailRow label={t("control.engineStatus.detail.noProgress")} value={noProgressText} tone="warn" />}
         </div>
       )}
     </div>

--- a/src/renderer/features/inventory/InventoryDrawer.tsx
+++ b/src/renderer/features/inventory/InventoryDrawer.tsx
@@ -16,6 +16,7 @@ import {
   formatPercent,
   formatRelative,
 } from "@renderer/features/overview/formatters";
+import { useI18n } from "@renderer/shared/i18n";
 
 export type InventoryDrawerProps = {
   drop: InventoryItem | null;
@@ -34,6 +35,8 @@ export function InventoryDrawer({
   onOpenAccountLink,
   onAddPriorityGame,
 }: InventoryDrawerProps) {
+  const { t } = useI18n();
+
   React.useEffect(() => {
     if (!drop) return;
     const onKey = (e: KeyboardEvent) => {
@@ -60,7 +63,7 @@ export function InventoryDrawer({
     <>
       <button
         type="button"
-        aria-label="Close drawer"
+        aria-label={t("inventory.drawer.closeAria")}
         onClick={onClose}
         className="fixed inset-0 z-40 bg-black/40 backdrop-blur-[2px] cursor-default"
       />
@@ -68,15 +71,15 @@ export function InventoryDrawer({
       <aside
         role="dialog"
         aria-modal="true"
-        aria-label="Drop details"
+        aria-label={t("inventory.drawer.title")}
         className="fixed right-0 top-0 bottom-0 z-50 w-[400px] max-w-full bg-[color:var(--dp-bg-elevated)] border-l border-[color:var(--dp-border)] shadow-2xl flex flex-col"
       >
         <div className="flex items-center justify-between px-5 py-4 border-b border-[color:var(--dp-border-soft)]">
-          <SectionLabel inline>drop details</SectionLabel>
+          <SectionLabel inline>{t("inventory.drawer.title")}</SectionLabel>
           <button
             type="button"
             onClick={onClose}
-            aria-label="Close"
+            aria-label={t("inventory.drawer.close")}
             className="flex h-7 w-7 items-center justify-center rounded-[var(--dp-radius-xs)] text-[color:var(--dp-text-dimmer)] hover:bg-[color:var(--dp-bg-elevated-2)] hover:text-[color:var(--dp-text)] transition-colors"
           >
             <X size={14} strokeWidth={1.8} />
@@ -115,7 +118,7 @@ export function InventoryDrawer({
 
           <div className="mb-5">
             <div className="font-mono text-[9px] uppercase tracking-[0.12em] text-[color:var(--dp-text-dimmer)] mb-1.5">
-              progress
+              {t("inventory.drawer.progress")}
             </div>
             <div className="flex items-center gap-2 mb-1">
               <div className="flex-1 h-[4px] rounded-[2px] bg-[color:var(--dp-border)] overflow-hidden">
@@ -133,15 +136,18 @@ export function InventoryDrawer({
               </span>
             </div>
             <div className="font-mono text-[10px] text-[color:var(--dp-text-dimmer)]">
-              {formatHourMinute(drop.earnedMinutes)} watched ·{" "}
-              {drop.requiredMinutes > 0 ? formatHourMinute(drop.requiredMinutes) : "—"} required
+              {t("inventory.drawer.watchedRequired", {
+                watched: formatHourMinute(drop.earnedMinutes),
+                required:
+                  drop.requiredMinutes > 0 ? formatHourMinute(drop.requiredMinutes) : "—",
+              })}
             </div>
           </div>
 
           {blockingLabel && (
             <div className="mb-5 rounded-[var(--dp-radius-md)] border border-[rgba(248,113,113,0.20)] bg-[rgba(248,113,113,0.08)] px-3 py-2">
               <div className="font-mono text-[9px] uppercase tracking-[0.12em] text-[color:var(--dp-signal-err)] mb-1">
-                blocked
+                {t("inventory.drawer.blocked")}
               </div>
               <div className="text-[12px] text-[color:var(--dp-text)]">{blockingLabel}</div>
             </div>
@@ -150,17 +156,17 @@ export function InventoryDrawer({
           {campaign && (
             <div className="mb-5">
               <div className="font-mono text-[9px] uppercase tracking-[0.12em] text-[color:var(--dp-text-dimmer)] mb-1.5">
-                campaign
+                {t("inventory.drawer.campaign")}
               </div>
               <div className="text-[13px] text-[color:var(--dp-text)] mb-0.5">{campaign.name}</div>
               {campaign.startsAt && (
                 <div className="font-mono text-[10px] text-[color:var(--dp-text-dimmer)]">
-                  starts {formatRelative(Date.parse(campaign.startsAt))}
+                  {t("inventory.drawer.starts")} {formatRelative(Date.parse(campaign.startsAt))}
                 </div>
               )}
               {campaign.endsAt && (
                 <div className="font-mono text-[10px] text-[color:var(--dp-text-dimmer)]">
-                  ends {formatRelative(Date.parse(campaign.endsAt))}
+                  {t("inventory.drawer.ends")} {formatRelative(Date.parse(campaign.endsAt))}
                 </div>
               )}
             </div>
@@ -174,7 +180,7 @@ export function InventoryDrawer({
                 onClick={() => onOpenAccountLink(campaign?.accountLinkUrl)}
                 title={campaign?.accountLinkUrl}
               >
-                <ExternalLink size={11} strokeWidth={1.8} /> link account
+                <ExternalLink size={11} strokeWidth={1.8} /> {t("inventory.header.linkAccount")}
               </Button>
             )}
             {showAddPriority && drop.game && (
@@ -183,12 +189,12 @@ export function InventoryDrawer({
                 size="dp-md"
                 onClick={() => onAddPriorityGame(drop.game.trim())}
               >
-                add {drop.game} to priorities
+                {t("inventory.drawer.addToPriorities", { game: drop.game })}
               </Button>
             )}
             {!showLinkAction && !showAddPriority && (
               <div className="font-mono text-[10px] text-[color:var(--dp-text-dimmer)] text-center py-2">
-                no actions available
+                {t("inventory.drawer.noActions")}
               </div>
             )}
           </div>

--- a/src/renderer/features/inventory/InventoryFilterStrip.tsx
+++ b/src/renderer/features/inventory/InventoryFilterStrip.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import type { FilterKey } from "@renderer/shared/types";
 import { cn } from "@renderer/shared/lib/utils";
+import { useI18n } from "@renderer/shared/i18n";
 
 export type FilterChipKey = Exclude<FilterKey, "excluded">;
 
@@ -10,24 +11,29 @@ export type InventoryFilterStripProps = {
   counts?: Partial<Record<FilterChipKey, number>>;
 };
 
-const CHIP_DEFS: Array<{ key: FilterChipKey; label: string }> = [
-  { key: "all", label: "all" },
-  { key: "priority-games", label: "priority" },
-  { key: "in-progress", label: "live" },
-  { key: "upcoming", label: "upcoming" },
-  { key: "finished", label: "claimed" },
-  { key: "not-linked", label: "not linked" },
-  { key: "expired", label: "expired" },
-];
-
 export function InventoryFilterStrip({
   filter,
   onFilterChange,
   counts,
 }: InventoryFilterStripProps) {
+  const { t } = useI18n();
+
+  const CHIP_DEFS = React.useMemo(
+    () => [
+      { key: "all" as FilterChipKey, label: t("inventory.filter.all") },
+      { key: "priority-games" as FilterChipKey, label: t("inventory.filter.priority") },
+      { key: "in-progress" as FilterChipKey, label: t("inventory.filter.live") },
+      { key: "upcoming" as FilterChipKey, label: t("inventory.filter.upcoming") },
+      { key: "finished" as FilterChipKey, label: t("inventory.filter.claimed") },
+      { key: "not-linked" as FilterChipKey, label: t("inventory.filter.notLinked") },
+      { key: "expired" as FilterChipKey, label: t("inventory.filter.expired") },
+    ],
+    [t],
+  );
+
   const active: FilterChipKey = filter === "excluded" ? "all" : (filter as FilterChipKey);
   return (
-    <div className="flex flex-wrap gap-1.5" role="tablist" aria-label="Inventory filter">
+    <div className="flex flex-wrap gap-1.5" role="tablist" aria-label={t("inventory.filter.aria")}>
       {CHIP_DEFS.map((def) => {
         const isActive = def.key === active;
         const count = counts?.[def.key];

--- a/src/renderer/features/inventory/InventoryHeader.tsx
+++ b/src/renderer/features/inventory/InventoryHeader.tsx
@@ -10,6 +10,7 @@ import {
   SelectValue,
 } from "@renderer/shared/components/ui/select";
 import { Search, RotateCw, ExternalLink } from "@renderer/shared/lib/icons";
+import { useI18n } from "@renderer/shared/i18n";
 
 export type InventoryHeaderProps = {
   totalDrops: number;
@@ -40,15 +41,21 @@ export function InventoryHeader({
   unlinkedCount,
   onOpenAccountLink,
 }: InventoryHeaderProps) {
+  const { t } = useI18n();
   return (
     <div className="flex flex-col gap-3">
       <div className="flex flex-wrap items-end justify-between gap-3">
         <div>
           <h2 className="text-[22px] font-medium tracking-[-0.01em] text-[color:var(--dp-text)] leading-tight">
-            Inventory
+            {t("inventory.header.title")}
           </h2>
           <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-[color:var(--dp-text-dimmer)] mt-1">
-            {filteredDrops} of {totalDrops} drops
+            {t(
+              totalDrops === 1
+                ? "inventory.header.countOf.one"
+                : "inventory.header.countOf.other",
+              { shown: filteredDrops, total: totalDrops },
+            )}
           </div>
         </div>
         <div className="flex flex-wrap items-center gap-2">
@@ -62,7 +69,7 @@ export function InventoryHeader({
               tone="dp"
               value={search}
               onChange={(e) => onSearchChange(e.target.value)}
-              placeholder="search drops…"
+              placeholder={t("inventory.header.searchPlaceholder")}
               className="pl-7 w-[200px]"
             />
           </div>
@@ -72,7 +79,7 @@ export function InventoryHeader({
             </SelectTrigger>
             <SelectContent>
               <SelectGroup>
-                <SelectItem value="all">All games</SelectItem>
+                <SelectItem value="all">{t("inventory.header.allGames")}</SelectItem>
                 {uniqueGames.map((g) => (
                   <SelectItem key={g} value={g}>
                     {g}
@@ -86,14 +93,14 @@ export function InventoryHeader({
             size="dp-md"
             onClick={onRefresh}
             disabled={refreshDisabled}
-            title="Refresh inventory"
+            title={t("inventory.header.refreshTitle")}
           >
             <RotateCw
               size={11}
               strokeWidth={1.8}
               className={refreshing ? "animate-spin" : undefined}
             />
-            {refreshing ? "refreshing" : "refresh"}
+            {refreshing ? t("inventory.header.refreshing") : t("inventory.header.refresh")}
           </Button>
         </div>
       </div>
@@ -101,10 +108,15 @@ export function InventoryHeader({
       {unlinkedCount > 0 && (
         <div className="flex flex-wrap items-center justify-between gap-3 rounded-[var(--dp-radius-md)] border border-[rgba(251,191,36,0.20)] bg-[rgba(251,191,36,0.06)] px-4 py-2">
           <div className="font-mono text-[11px] text-[color:var(--dp-signal-warn)]">
-            {unlinkedCount} drop{unlinkedCount === 1 ? "" : "s"} need account-link
+            {t(
+              unlinkedCount === 1
+                ? "inventory.header.dropsNeedLink.one"
+                : "inventory.header.dropsNeedLink.other",
+              { count: unlinkedCount },
+            )}
           </div>
           <Button variant="dp-outline" size="dp-sm" onClick={onOpenAccountLink}>
-            <ExternalLink size={11} strokeWidth={1.8} /> link account
+            <ExternalLink size={11} strokeWidth={1.8} /> {t("inventory.header.linkAccount")}
           </Button>
         </div>
       )}

--- a/src/renderer/features/inventory/InventoryTable.tsx
+++ b/src/renderer/features/inventory/InventoryTable.tsx
@@ -7,6 +7,7 @@ import { cn } from "@renderer/shared/lib/utils";
 import type { DropSortKey, SortDirection } from "./inventoryFilters";
 import { dropStatusLabel, dropStatusTone, dropTitleFallback } from "./inventoryFormatters";
 import { formatHourMinute, formatPercent } from "@renderer/features/overview/formatters";
+import { useI18n } from "@renderer/shared/i18n";
 
 export type InventoryTableProps = {
   items: InventoryItem[];
@@ -23,14 +24,6 @@ type ColumnDef = {
   sortable: boolean;
 };
 
-const COLUMNS: ColumnDef[] = [
-  { key: null, label: "", sortable: false }, // thumbnail
-  { key: "title", label: "drop · game", sortable: true },
-  { key: "watched", label: "watched", sortable: true },
-  { key: "progress", label: "progress", sortable: true },
-  { key: "status", label: "status", sortable: true },
-];
-
 const COLUMNS_TEMPLATE = "36px 2fr 1fr 1.4fr 100px";
 
 export function InventoryTable({
@@ -41,6 +34,18 @@ export function InventoryTable({
   onSelectDrop,
   emptyMessage,
 }: InventoryTableProps) {
+  const { t } = useI18n();
+
+  const COLUMNS = React.useMemo(
+    (): ColumnDef[] => [
+      { key: null, label: "", sortable: false }, // thumbnail
+      { key: "title", label: t("queue.table.dropGame"), sortable: true },
+      { key: "watched", label: t("queue.table.watched"), sortable: true },
+      { key: "progress", label: t("queue.table.progress"), sortable: true },
+      { key: "status", label: t("queue.table.status"), sortable: true },
+    ],
+    [t],
+  );
   if (items.length === 0) {
     return (
       <div className="rounded-[var(--dp-radius-lg)] border border-[color:var(--dp-border)] bg-[color:var(--dp-bg-elevated)] px-5 py-12 text-center">

--- a/src/renderer/features/overview/ActivityPanel.tsx
+++ b/src/renderer/features/overview/ActivityPanel.tsx
@@ -3,6 +3,7 @@ import { FeedItem } from "@renderer/shared/components/ui/feed-item";
 import { Check } from "@renderer/shared/lib/icons";
 import type { InventoryItem } from "@renderer/shared/types";
 import { formatRelative } from "./formatters";
+import { useI18n } from "@renderer/shared/i18n";
 
 export type ActivityPanelProps = {
   items: InventoryItem[];
@@ -10,6 +11,7 @@ export type ActivityPanelProps = {
 };
 
 export function ActivityPanel({ items, maxItems = 5 }: ActivityPanelProps) {
+  const { t } = useI18n();
   const claimed = React.useMemo(() => {
     return items.filter((it) => it.status === "claimed").slice(0, maxItems);
   }, [items, maxItems]);
@@ -17,11 +19,11 @@ export function ActivityPanel({ items, maxItems = 5 }: ActivityPanelProps) {
   return (
     <div className="rounded-[var(--dp-radius-lg)] border border-[color:var(--dp-border)] bg-[color:var(--dp-bg-elevated)] px-4 py-4">
       <span className="block font-mono text-[11px] uppercase tracking-[0.14em] text-[color:var(--dp-text-dim)] mb-3">
-        recent activity
+        {t("activity.header")}
       </span>
       {claimed.length === 0 ? (
         <div className="py-2 font-mono text-[11px] text-[color:var(--dp-text-dimmer)]">
-          no claims yet
+          {t("activity.empty")}
         </div>
       ) : (
         claimed.map((item, idx) => {
@@ -30,7 +32,7 @@ export function ActivityPanel({ items, maxItems = 5 }: ActivityPanelProps) {
             <>
               <span style={{ color: "var(--dp-accent)" }}>{item.game}</span>
               {" · "}
-              {claimedAt ? formatRelative(claimedAt) : "recently"}
+              {claimedAt ? formatRelative(claimedAt) : t("activity.recently")}
             </>
           );
           return (
@@ -40,7 +42,7 @@ export function ActivityPanel({ items, maxItems = 5 }: ActivityPanelProps) {
               icon={<Check />}
               msg={
                 <>
-                  Claimed <strong>{item.title}</strong>
+                  {t("activity.claimedPrefix")} <strong>{item.title}</strong>
                 </>
               }
               meta={meta}

--- a/src/renderer/features/overview/AttentionStrip.tsx
+++ b/src/renderer/features/overview/AttentionStrip.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { Pill } from "@renderer/shared/components/ui/pill";
 import type { ChannelTrackerStatus, ErrorInfo } from "@renderer/shared/types";
+import { useI18n } from "@renderer/shared/i18n";
 
 export type AttentionStripProps = {
   claimableDrops: number;
@@ -17,27 +18,31 @@ export function AttentionStrip({
   channelsCount,
   trackerStatus,
 }: AttentionStripProps) {
+  const { t } = useI18n();
   const pills: React.ReactNode[] = [];
 
   if (claimableDrops > 0) {
+    const claimText = claimableDrops === 1
+      ? t("attention.claimReady", { count: claimableDrops })
+      : t("attention.claimsReady", { count: claimableDrops });
     pills.push(
       <Pill key="claim-ready" tone="warn" dot>
-        {claimableDrops} claim ready
+        {claimText}
       </Pill>,
     );
   }
   if (watchError) {
-    const tooltip = watchError.message ?? watchError.code ?? "watch error";
+    const tooltip = watchError.message ?? watchError.code ?? t("attention.watchError");
     pills.push(
       <Pill key="watch-err" tone="err" dot title={tooltip}>
-        watch error
+        {t("attention.watchError")}
       </Pill>,
     );
   }
   if (activeGame && channelsCount === 0) {
     pills.push(
       <Pill key="no-channels" tone="warn">
-        no channels
+        {t("attention.noChannels")}
       </Pill>,
     );
   }
@@ -48,7 +53,7 @@ export function AttentionStrip({
   ) {
     pills.push(
       <Pill key="tracker" tone="err" dot>
-        tracker {trackerStatus.connectionState}
+        {t("attention.trackerLabel", { state: trackerStatus.connectionState })}
       </Pill>,
     );
   }

--- a/src/renderer/features/overview/EnginePanel.tsx
+++ b/src/renderer/features/overview/EnginePanel.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { formatRelative, formatUptime } from "./formatters";
+import { useI18n } from "@renderer/shared/i18n";
 
 export type EnginePanelProps = {
   lastWatchOk?: number | null;
@@ -12,6 +13,7 @@ export function EnginePanel({
   cycleSeconds = 30,
   cadenceSeconds = 30,
 }: EnginePanelProps) {
+  const { t } = useI18n();
   const sessionStartRef = React.useRef<number>(Date.now());
   const [now, setNow] = React.useState<number>(() => Date.now());
 
@@ -20,22 +22,22 @@ export function EnginePanel({
     return () => window.clearInterval(id);
   }, []);
 
-  const rows: Array<{ key: string; value: string; tone?: "ok" }> = [
-    { key: "watch_cycle", value: `${cycleSeconds}s` },
-    { key: "last_refresh", value: formatRelative(lastWatchOk, now) },
-    { key: "cadence", value: `${cadenceSeconds}s` },
-    { key: "uptime", value: formatUptime(sessionStartRef.current, now) },
+  const rows: Array<{ id: string; label: string; value: string; tone?: "ok" }> = [
+    { id: "watchCycle", label: t("engine.row.watchCycle"), value: `${cycleSeconds}s` },
+    { id: "lastRefresh", label: t("engine.row.lastRefresh"), value: formatRelative(lastWatchOk, now) },
+    { id: "cadence", label: t("engine.row.cadence"), value: `${cadenceSeconds}s` },
+    { id: "uptime", label: t("engine.row.uptime"), value: formatUptime(sessionStartRef.current, now) },
   ];
 
   return (
     <div className="rounded-[var(--dp-radius-lg)] border border-[color:var(--dp-border)] bg-[color:var(--dp-bg-elevated)] px-4 py-4">
       <span className="block font-mono text-[11px] uppercase tracking-[0.14em] text-[color:var(--dp-text-dim)] mb-3">
-        engine
+        {t("engine.header")}
       </span>
       <div className="grid gap-2">
         {rows.map((row) => (
-          <div key={row.key} className="flex justify-between font-mono text-[11px]">
-            <span className="text-[color:var(--dp-text-dimmer)]">{row.key}</span>
+          <div key={row.id} className="flex justify-between font-mono text-[11px]">
+            <span className="text-[color:var(--dp-text-dimmer)]">{row.label}</span>
             <span
               className={
                 row.tone === "ok"

--- a/src/renderer/features/overview/HeroPanel.tsx
+++ b/src/renderer/features/overview/HeroPanel.tsx
@@ -4,6 +4,7 @@ import { Button } from "@renderer/shared/components/ui/button";
 import { SectionLabel } from "@renderer/shared/components/ui/section-label";
 import { Check, Pause, RotateCw } from "@renderer/shared/lib/icons";
 import { formatRemainingFromEta } from "./formatters";
+import { useI18n } from "@renderer/shared/i18n";
 
 export type HeroPanelProps = {
   activeGame?: string;
@@ -36,6 +37,7 @@ export function HeroPanel({
   onPause,
   onSwitchTarget,
 }: HeroPanelProps) {
+  const { t } = useI18n();
   const [now, setNow] = React.useState<number>(() => Date.now());
   React.useEffect(() => {
     const hasEta = typeof activeDropEta === "number" && Number.isFinite(activeDropEta);
@@ -48,12 +50,12 @@ export function HeroPanel({
   const progressPct = Math.max(0, Math.min(100, Math.round(targetProgress)));
   const openDrops = Math.max(0, totalDrops - claimedDrops);
   const hasClaimable = claimableDrops > 0;
-  const title = activeDropTitle?.trim() || activeGame || "No active target";
+  const title = activeDropTitle?.trim() || activeGame || t("hero.noActiveTarget");
   const channel = activeGame || "—";
 
   return (
     <div>
-      <SectionLabel>currently watching</SectionLabel>
+      <SectionLabel>{t("hero.nowWatching")}</SectionLabel>
       <div className="mt-3 relative overflow-hidden rounded-[var(--dp-radius-lg)] border border-[color:var(--dp-border)] bg-[color:var(--dp-bg-elevated)] p-6">
         {/* Top-right radial glow */}
         <div
@@ -73,7 +75,7 @@ export function HeroPanel({
               className={`inline-block h-[6px] w-[6px] rounded-full bg-[color:var(--dp-accent)] ${isLive ? "animate-pulse" : "opacity-40"}`}
               style={{ boxShadow: "0 0 10px var(--dp-accent-glow)" }}
             />
-            {isLive ? "LIVE · earning drop" : "IDLE"}
+            {isLive ? t("hero.statusLive") : t("hero.statusIdle")}
           </div>
         </div>
 
@@ -91,7 +93,7 @@ export function HeroPanel({
           style={{ gridTemplateColumns: "1.4fr 1fr 1fr 1fr" }}
         >
           <div className="pr-4">
-            <Stat label="eta" value={etaText} sub={`${progressPct}% complete`} accent />
+            <Stat label={t("hero.stat.eta")} value={etaText} sub={t("hero.stat.percentComplete", { pct: progressPct })} accent />
             <div className="mt-2.5 h-[3px] rounded-[2px] bg-[color:var(--dp-border)] overflow-hidden">
               <div
                 className="h-full rounded-[2px]"
@@ -104,18 +106,18 @@ export function HeroPanel({
             </div>
           </div>
           <div className="px-[18px] border-l border-[color:var(--dp-border-soft)]">
-            <Stat label="channels" value={String(channelsCount)} />
+            <Stat label={t("hero.stat.channels")} value={String(channelsCount)} />
           </div>
           <div className="px-[18px] border-l border-[color:var(--dp-border-soft)]">
             <Stat
-              label="claims ready"
+              label={t("hero.stat.claimsReady")}
               value={String(claimableDrops)}
-              sub={hasClaimable ? "use inventory" : undefined}
+              sub={hasClaimable ? t("hero.stat.useInventory") : undefined}
               subTone={hasClaimable ? "ok" : "default"}
             />
           </div>
           <div className="px-[18px] border-l border-[color:var(--dp-border-soft)]">
-            <Stat label="open drops" value={String(openDrops)} />
+            <Stat label={t("hero.stat.openDrops")} value={String(openDrops)} />
           </div>
         </div>
 
@@ -125,9 +127,9 @@ export function HeroPanel({
             variant="dp-primary"
             size="dp-md"
             disabled={!hasClaimable}
-            title="Use Inventory view to claim"
+            title={t("hero.title.useInventoryToClaim")}
           >
-            <Check size={11} strokeWidth={2.2} /> claim now
+            <Check size={11} strokeWidth={2.2} /> {t("hero.button.claimNow")}
           </Button>
           <Button
             variant="dp-secondary"
@@ -136,13 +138,13 @@ export function HeroPanel({
             disabled={!onPause || !isLive}
             title={
               !onPause
-                ? "Phase 5 will wire this"
+                ? t("hero.title.wireLater")
                 : !isLive
-                  ? "Engine is not running"
-                  : "Pause the watch engine"
+                  ? t("hero.title.engineNotRunning")
+                  : t("hero.title.pauseEngine")
             }
           >
-            <Pause size={11} strokeWidth={1.8} /> pause
+            <Pause size={11} strokeWidth={1.8} /> {t("hero.button.pause")}
           </Button>
           <Button
             variant="dp-outline"
@@ -150,10 +152,10 @@ export function HeroPanel({
             onClick={onSwitchTarget}
             disabled={!onSwitchTarget}
             title={
-              onSwitchTarget ? "Open Priorities view to switch target" : "Phase 5 will wire this"
+              onSwitchTarget ? t("hero.title.openPrioritiesToSwitch") : t("hero.title.wireLater")
             }
           >
-            <RotateCw size={11} strokeWidth={1.8} /> switch target
+            <RotateCw size={11} strokeWidth={1.8} /> {t("hero.button.switchTarget")}
           </Button>
         </div>
       </div>

--- a/src/renderer/features/overview/QueuePanel.tsx
+++ b/src/renderer/features/overview/QueuePanel.tsx
@@ -10,6 +10,7 @@ import { Table, TableHead, TableRow, TableCell } from "@renderer/shared/componen
 import { Pill } from "@renderer/shared/components/ui/pill";
 import type { InventoryItem } from "@renderer/shared/types";
 import { formatHourMinute, formatPercent, padRank } from "./formatters";
+import { useI18n } from "@renderer/shared/i18n";
 
 export type QueuePanelProps = {
   items: InventoryItem[];
@@ -18,6 +19,7 @@ export type QueuePanelProps = {
 };
 
 export function QueuePanel({ items, onManageClick, maxRows = 8 }: QueuePanelProps) {
+  const { t } = useI18n();
   const queued = React.useMemo(() => {
     return items
       .filter((it) => it.status !== "claimed")
@@ -33,23 +35,23 @@ export function QueuePanel({ items, onManageClick, maxRows = 8 }: QueuePanelProp
     <Card className="bg-[color:var(--dp-bg-elevated)] border-[color:var(--dp-border)] rounded-[var(--dp-radius-lg)]">
       <CardHeader className="flex flex-row items-center border-b border-[color:var(--dp-border-soft)] py-3.5">
         <CardTitle className="font-mono text-[11px] uppercase tracking-[0.14em] text-[color:var(--dp-text-dim)] font-normal">
-          queue · next up
+          {t("queue.header")}
         </CardTitle>
-        {onManageClick && <CardAction onClick={onManageClick}>manage →</CardAction>}
+        {onManageClick && <CardAction onClick={onManageClick}>{t("queue.manage")}</CardAction>}
       </CardHeader>
       <CardContent className="p-0">
         {queued.length === 0 ? (
           <div className="px-5 py-8 text-center font-mono text-[11px] text-[color:var(--dp-text-dimmer)]">
-            no drops in queue
+            {t("queue.empty")}
           </div>
         ) : (
           <Table columns="40px 2fr 1fr 1fr 100px">
             <TableHead>
               <span>#</span>
-              <span>drop · game</span>
-              <span>watched</span>
-              <span>progress</span>
-              <span>status</span>
+              <span>{t("queue.table.dropGame")}</span>
+              <span>{t("queue.table.watched")}</span>
+              <span>{t("queue.table.progress")}</span>
+              <span>{t("queue.table.status")}</span>
             </TableHead>
             {queued.map((item, idx) => {
               const watched = formatHourMinute(item.earnedMinutes);
@@ -78,7 +80,7 @@ export function QueuePanel({ items, onManageClick, maxRows = 8 }: QueuePanelProp
                   </TableCell>
                   <TableCell>
                     <Pill tone={tone} dot={status === "live"}>
-                      {status}
+                      {status === "live" ? t("queue.pill.live") : t("queue.pill.queued")}
                     </Pill>
                   </TableCell>
                 </TableRow>

--- a/src/renderer/features/priority/PriorityAddPanel.tsx
+++ b/src/renderer/features/priority/PriorityAddPanel.tsx
@@ -11,6 +11,7 @@ import {
   SelectValue,
 } from "@renderer/shared/components/ui/select";
 import { Plus } from "@renderer/shared/lib/icons";
+import { useI18n } from "@renderer/shared/i18n";
 
 const NO_GAME_SELECT_VALUE = "__dp_none__";
 
@@ -37,14 +38,15 @@ export function PriorityAddPanel({
   obeyPriority,
   setObeyPriority,
 }: PriorityAddPanelProps) {
+  const { t } = useI18n();
   const hasSelectableSelectedGame = selectableDropGames.includes(selectedGame);
 
   return (
     <div className="rounded-[var(--dp-radius-lg)] border border-[color:var(--dp-border)] bg-[color:var(--dp-bg-elevated)] p-5 flex flex-col gap-5">
       <div>
-        <SectionLabel inline>add from your drops</SectionLabel>
+        <SectionLabel inline>{t("priorities.add.fromDropsTitle")}</SectionLabel>
         <p className="font-mono text-[10px] text-[color:var(--dp-text-dimmer)] mt-1">
-          pick a game that currently has live drops
+          {t("priorities.add.fromDropsHint")}
         </p>
         {selectableDropGames.length > 0 ? (
           <div className="flex gap-2 mt-3">
@@ -55,11 +57,13 @@ export function PriorityAddPanel({
               }
             >
               <SelectTrigger tone="dp" className="flex-1" aria-label="Add from drops">
-                <SelectValue placeholder="select a game…" />
+                <SelectValue placeholder={t("priorities.add.selectPlaceholder")} />
               </SelectTrigger>
               <SelectContent>
                 <SelectGroup>
-                  <SelectItem value={NO_GAME_SELECT_VALUE}>select a game…</SelectItem>
+                  <SelectItem value={NO_GAME_SELECT_VALUE}>
+                    {t("priorities.add.selectPlaceholder")}
+                  </SelectItem>
                   {selectableDropGames.map((g) => (
                     <SelectItem key={g} value={g}>
                       {g}
@@ -74,20 +78,20 @@ export function PriorityAddPanel({
               onClick={addGameFromSelect}
               disabled={!hasSelectableSelectedGame}
             >
-              <Plus size={11} strokeWidth={2} /> add
+              <Plus size={11} strokeWidth={2} /> {t("priorities.add.addButton")}
             </Button>
           </div>
         ) : (
           <div className="font-mono text-[10px] text-[color:var(--dp-text-dimmer)] mt-3 py-2">
-            no extra games with live drops
+            {t("priorities.addEmpty")}
           </div>
         )}
       </div>
 
       <div>
-        <SectionLabel inline>add manually</SectionLabel>
+        <SectionLabel inline>{t("priorities.manualTitle")}</SectionLabel>
         <p className="font-mono text-[10px] text-[color:var(--dp-text-dimmer)] mt-1">
-          type any game name, even ones with no live drops yet
+          {t("priorities.add.manualHint")}
         </p>
         <div className="flex gap-2 mt-3">
           <Input
@@ -100,12 +104,12 @@ export function PriorityAddPanel({
                 addGame();
               }
             }}
-            placeholder="game name…"
+            placeholder={t("priorities.add.manualPlaceholder")}
             className="flex-1"
             aria-label="Add game manually"
           />
           <Button variant="dp-primary" size="dp-md" onClick={addGame} disabled={!newGame.trim()}>
-            <Plus size={11} strokeWidth={2} /> add
+            <Plus size={11} strokeWidth={2} /> {t("priorities.add.addButton")}
           </Button>
         </div>
       </div>
@@ -120,12 +124,12 @@ export function PriorityAddPanel({
         />
         <label htmlFor="dp-obey-priority" className="flex-1 cursor-pointer">
           <div className="text-[12px] text-[color:var(--dp-text)] font-medium">
-            strict priority order
+            {t("priorities.add.strictLabel")}
           </div>
           <div className="font-mono text-[10px] text-[color:var(--dp-text-dimmer)] mt-0.5">
             {obeyPriority
-              ? "watch engine sticks to the highest-priority live game"
-              : "watch engine may pick any live game when the top is blocked"}
+              ? t("priorities.ruleStrictHint")
+              : t("priorities.ruleFlexibleHint")}
           </div>
         </label>
       </div>

--- a/src/renderer/features/priority/PriorityHeader.tsx
+++ b/src/renderer/features/priority/PriorityHeader.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { Stat } from "@renderer/shared/components/ui/stat";
+import { useI18n } from "@renderer/shared/i18n";
 
 export type PriorityHeaderProps = {
   totalCount: number;
@@ -18,6 +19,7 @@ export function PriorityHeader({
   topGame,
   obeyPriority,
 }: PriorityHeaderProps) {
+  const { t } = useI18n();
   const currentTargetValue = activeTargetGame || "—";
   const currentTargetSub = watchingGame
     ? `watching ${watchingGame}`
@@ -32,7 +34,7 @@ export function PriorityHeader({
       <div className="flex flex-wrap items-end justify-between gap-3">
         <div>
           <h2 className="text-[22px] font-medium tracking-[-0.01em] text-[color:var(--dp-text)] leading-tight">
-            Priorities
+            {t("priorities.title")}
           </h2>
           <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-[color:var(--dp-text-dimmer)] mt-1">
             {totalCount} game{totalCount === 1 ? "" : "s"} ranked
@@ -46,7 +48,7 @@ export function PriorityHeader({
       >
         <div className="pr-4">
           <Stat
-            label="current target"
+            label={t("priorities.currentTarget")}
             value={currentTargetValue}
             sub={currentTargetSub}
             accent={!!activeTargetGame}
@@ -56,7 +58,7 @@ export function PriorityHeader({
           <Stat label="queue live" value={queueHealthValue} sub="live / total" />
         </div>
         <div className="pl-4 border-l border-[color:var(--dp-border-soft)]">
-          <Stat label="top slot" value={topGameValue} sub="position 01" />
+          <Stat label={t("priorities.topSlot")} value={topGameValue} sub="position 01" />
         </div>
       </div>
     </div>

--- a/src/renderer/features/priority/PriorityHeader.tsx
+++ b/src/renderer/features/priority/PriorityHeader.tsx
@@ -22,12 +22,18 @@ export function PriorityHeader({
   const { t } = useI18n();
   const currentTargetValue = activeTargetGame || "—";
   const currentTargetSub = watchingGame
-    ? `watching ${watchingGame}`
+    ? t("priorities.header.watchingNow", { game: watchingGame })
     : obeyPriority
-      ? "strict mode"
-      : "flexible mode";
+      ? t("priorities.header.modeStrict")
+      : t("priorities.header.modeFlexible");
   const queueHealthValue = totalCount > 0 ? `${livePriorityCount}/${totalCount}` : "—";
   const topGameValue = topGame || "—";
+  const rankedCountLabel = t(
+    totalCount === 1
+      ? "priorities.header.rankedCount.one"
+      : "priorities.header.rankedCount.other",
+    { count: totalCount },
+  );
 
   return (
     <div className="flex flex-col gap-3">
@@ -37,7 +43,7 @@ export function PriorityHeader({
             {t("priorities.title")}
           </h2>
           <div className="font-mono text-[10px] uppercase tracking-[0.12em] text-[color:var(--dp-text-dimmer)] mt-1">
-            {totalCount} game{totalCount === 1 ? "" : "s"} ranked
+            {rankedCountLabel}
           </div>
         </div>
       </div>
@@ -55,10 +61,18 @@ export function PriorityHeader({
           />
         </div>
         <div className="px-4 border-l border-[color:var(--dp-border-soft)]">
-          <Stat label="queue live" value={queueHealthValue} sub="live / total" />
+          <Stat
+            label={t("priorities.queueHealth")}
+            value={queueHealthValue}
+            sub={t("priorities.header.liveTotalSub")}
+          />
         </div>
         <div className="pl-4 border-l border-[color:var(--dp-border-soft)]">
-          <Stat label={t("priorities.topSlot")} value={topGameValue} sub="position 01" />
+          <Stat
+            label={t("priorities.topSlot")}
+            value={topGameValue}
+            sub={t("priorities.header.position", { rank: "01" })}
+          />
         </div>
       </div>
     </div>

--- a/src/renderer/features/priority/PriorityList.tsx
+++ b/src/renderer/features/priority/PriorityList.tsx
@@ -15,6 +15,7 @@ import {
 } from "@dnd-kit/sortable";
 import { PriorityRow } from "./PriorityRow";
 import { derivePriorityRowState } from "./priorityHelpers";
+import { useI18n } from "@renderer/shared/i18n";
 
 export type PriorityListProps = {
   priorityGames: string[];
@@ -33,6 +34,7 @@ export function PriorityList({
   movePriorityGame,
   removeGame,
 }: PriorityListProps) {
+  const { t } = useI18n();
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
@@ -53,10 +55,10 @@ export function PriorityList({
     return (
       <div className="rounded-[var(--dp-radius-lg)] border border-[color:var(--dp-border)] bg-[color:var(--dp-bg-elevated)] px-5 py-12 text-center">
         <p className="font-mono text-[11px] text-[color:var(--dp-text-dimmer)]">
-          no games prioritized yet
+          {t("priorities.list.empty")}
         </p>
         <p className="font-mono text-[10px] text-[color:var(--dp-text-dimmer)] mt-1 opacity-70">
-          add a game from the panel on the left
+          {t("priorities.list.emptyHint")}
         </p>
       </div>
     );

--- a/src/renderer/features/priority/PriorityRow.tsx
+++ b/src/renderer/features/priority/PriorityRow.tsx
@@ -4,6 +4,7 @@ import { CSS } from "@dnd-kit/utilities";
 import { GripVertical, X } from "@renderer/shared/lib/icons";
 import { Pill } from "@renderer/shared/components/ui/pill";
 import { cn } from "@renderer/shared/lib/utils";
+import { useI18n } from "@renderer/shared/i18n";
 import { padPriorityRank, type PriorityRowState } from "./priorityHelpers";
 
 export type PriorityRowProps = {
@@ -11,13 +12,6 @@ export type PriorityRowProps = {
   game: string;
   state: PriorityRowState;
   onRemove: (game: string) => void;
-};
-
-const STATE_LABEL: Record<PriorityRowState, string> = {
-  watching: "watching",
-  target: "target",
-  live: "live",
-  idle: "idle",
 };
 
 const STATE_TONE: Record<PriorityRowState, "accent" | "ok" | "info" | "dim"> = {
@@ -28,6 +22,18 @@ const STATE_TONE: Record<PriorityRowState, "accent" | "ok" | "info" | "dim"> = {
 };
 
 export function PriorityRow({ rank, game, state, onRemove }: PriorityRowProps) {
+  const { t } = useI18n();
+
+  const STATE_LABEL = React.useMemo<Record<PriorityRowState, string>>(
+    () => ({
+      watching: t("priorities.state.watching"),
+      target: t("priorities.state.target"),
+      live: t("priorities.state.live"),
+      idle: t("priorities.state.idle"),
+    }),
+    [t],
+  );
+
   const {
     attributes,
     listeners,
@@ -60,8 +66,8 @@ export function PriorityRow({ rank, game, state, onRemove }: PriorityRowProps) {
         ref={setActivatorNodeRef}
         {...attributes}
         {...listeners}
-        aria-label={`Drag ${game}`}
-        title={`Drag ${game}`}
+        aria-label={t("priorities.row.dragAria", { game })}
+        title={t("priorities.row.dragAria", { game })}
         className={cn(
           "flex h-6 w-6 items-center justify-center rounded-[var(--dp-radius-xs)] cursor-grab active:cursor-grabbing",
           "text-[color:var(--dp-text-dimmer)] opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[color:var(--dp-accent)]",
@@ -96,8 +102,8 @@ export function PriorityRow({ rank, game, state, onRemove }: PriorityRowProps) {
       <button
         type="button"
         onClick={() => onRemove(game)}
-        aria-label={`Remove ${game}`}
-        title={`Remove ${game}`}
+        aria-label={t("priorities.row.removeAria", { game })}
+        title={t("priorities.row.removeAria", { game })}
         className={cn(
           "flex h-6 w-6 items-center justify-center rounded-[var(--dp-radius-xs)]",
           "text-[color:var(--dp-text-dimmer)] opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[color:var(--dp-signal-err)]",

--- a/src/renderer/shared/i18n.tsx
+++ b/src/renderer/shared/i18n.tsx
@@ -764,6 +764,136 @@ const translations: Translations = {
     "error.update.unknown": "Unknown update error",
     "error.update.download_failed": "Update download failed",
     "error.update.install_failed": "Update install failed",
+
+    // hero.* additions — HeroPanel labels/buttons/titles
+    "hero.nowWatching": "currently watching",
+    "hero.statusLive": "LIVE · earning drop",
+    "hero.statusIdle": "IDLE",
+    "hero.noActiveTarget": "No active target",
+    "hero.stat.eta": "eta",
+    "hero.stat.channels": "channels",
+    "hero.stat.claimsReady": "claims ready",
+    "hero.stat.openDrops": "open drops",
+    "hero.stat.useInventory": "use inventory",
+    "hero.stat.percentComplete": "{pct}% complete",
+    "hero.button.claimNow": "claim now",
+    "hero.button.pause": "pause",
+    "hero.button.switchTarget": "switch target",
+    "hero.title.useInventoryToClaim": "Use Inventory view to claim",
+    "hero.title.engineNotRunning": "Engine is not running",
+    "hero.title.pauseEngine": "Pause the watch engine",
+    "hero.title.openPrioritiesToSwitch": "Open Priorities view to switch target",
+    "hero.title.wireLater": "Wiring coming in a follow-up phase",
+
+    // queue.* — new namespace, QueuePanel
+    "queue.header": "queue · next up",
+    "queue.manage": "manage →",
+    "queue.empty": "no drops in queue",
+    "queue.table.dropGame": "drop · game",
+    "queue.table.watched": "watched",
+    "queue.table.progress": "progress",
+    "queue.table.status": "status",
+    "queue.pill.live": "live",
+    "queue.pill.queued": "queued",
+
+    // activity.* — new namespace, ActivityPanel
+    "activity.header": "recent activity",
+    "activity.empty": "no claims yet",
+    "activity.claimedPrefix": "Claimed",
+    "activity.recently": "recently",
+
+    // engine.* — new namespace, EnginePanel (Overview)
+    "engine.header": "engine",
+    "engine.row.watchCycle": "watch_cycle",
+    "engine.row.lastRefresh": "last_refresh",
+    "engine.row.cadence": "cadence",
+    "engine.row.uptime": "uptime",
+
+    // attention.* — new namespace, AttentionStrip
+    "attention.claimReady": "{count} claim ready",
+    "attention.claimsReady": "{count} claims ready",
+    "attention.watchError": "watch error",
+    "attention.noChannels": "no channels",
+    "attention.trackerLabel": "tracker {state}",
+
+    // inventory.filter.* — InventoryFilterStrip chips (new keys only; all/upcoming/notLinked/expired already defined above)
+    "inventory.filter.aria": "Inventory filter",
+    "inventory.filter.priority": "priority",
+    "inventory.filter.live": "live",
+    "inventory.filter.claimed": "claimed",
+
+    // inventory.header.* — InventoryHeader
+    "inventory.header.title": "Inventory",
+    "inventory.header.searchPlaceholder": "search drops…",
+    "inventory.header.allGames": "All games",
+    "inventory.header.refreshTitle": "Refresh inventory",
+    "inventory.header.refreshing": "refreshing",
+    "inventory.header.refresh": "refresh",
+    "inventory.header.linkAccount": "link account",
+    "inventory.header.dropsNeedLink.one": "{count} drop needs account-link",
+    "inventory.header.dropsNeedLink.other": "{count} drops need account-link",
+    "inventory.header.countOf.one": "{shown} of {total} drop",
+    "inventory.header.countOf.other": "{shown} of {total} drops",
+
+    // inventory.drawer.* — InventoryDrawer
+    "inventory.drawer.title": "drop details",
+    "inventory.drawer.close": "Close",
+    "inventory.drawer.closeAria": "Close drawer",
+    "inventory.drawer.progress": "progress",
+    "inventory.drawer.blocked": "blocked",
+    "inventory.drawer.campaign": "campaign",
+    "inventory.drawer.starts": "starts",
+    "inventory.drawer.ends": "ends",
+    "inventory.drawer.watchedRequired": "watched · required",
+    "inventory.drawer.addToPriorities": "add {game} to priorities",
+    "inventory.drawer.noActions": "no actions available",
+
+    // control.engineStatus.* — EngineStatusPanel hardcoded remnants
+    "control.engineStatus.header": "engine status",
+    "control.engineStatus.why": "why",
+    "control.engineStatus.next": "next",
+    "control.engineStatus.detail.target": "target",
+    "control.engineStatus.detail.suppression": "suppression",
+    "control.engineStatus.detail.cooldowns": "cooldowns",
+    "control.engineStatus.detail.allowlist": "allowlist",
+    "control.engineStatus.detail.noProgress": "no-progress",
+
+    // control.activeSession.* — ActiveSessionPanel
+    "control.activeSession.nowWatching": "now watching",
+    "control.activeSession.noActiveSession": "no active session",
+    "control.activeSession.lastPing": "last ping",
+    "control.activeSession.loading": "loading…",
+    "control.activeSession.noStream": "no stream",
+    "control.activeSession.live": "live",
+    "control.activeSession.paused": "paused",
+    "control.activeSession.activeDrop": "active drop",
+    "control.activeSession.watchedRequiredEta": "{watched} watched · {required} required · eta {eta}",
+    "control.activeSession.watchedRequired": "{watched} watched · {required} required",
+    "control.activeSession.noFarmable": "no farmable drop on this channel",
+    "control.activeSession.engineIdle": "engine idle",
+    "control.activeSession.viewers": "viewers",
+
+    // control.channelGrid.* — ChannelGridPanel
+    "control.channelGrid.header": "live channels",
+    "control.channelGrid.refreshTitle": "Refresh channel list",
+    "control.channelGrid.refresh": "refresh",
+    "control.channelGrid.noTarget": "select a target game in Priorities to see live channels",
+    "control.channelGrid.watchingPill": "watching",
+
+    // control.campaignsPanel.* — CampaignsPanel
+    "control.campaignsPanel.empty": "no active campaigns",
+    "control.campaignsPanel.header": "campaigns",
+    "control.campaignsPanel.status.claimed": "claimed",
+    "control.campaignsPanel.status.blocked": "blocked",
+    "control.campaignsPanel.status.live": "live",
+    "control.campaignsPanel.status.queued": "queued",
+    "control.campaignsPanel.footerTotal": "total",
+    "control.campaignsPanel.footerDrops.one": "{count} drop",
+    "control.campaignsPanel.footerDrops.other": "{count} drops",
+
+    // priorities.row.*Aria — PriorityRow drag/remove aria
+    "priorities.row.dragAria": "Drag {game}",
+    "priorities.row.removeAria": "Remove {game}",
   },
   de: {
     "app.name": "DropPilot",
@@ -1518,6 +1648,136 @@ const translations: Translations = {
     "error.update.unknown": "Unbekannter Update-Fehler",
     "error.update.download_failed": "Update-Download fehlgeschlagen",
     "error.update.install_failed": "Update-Installation fehlgeschlagen",
+
+    // hero.* additions — HeroPanel labels/buttons/titles
+    "hero.nowWatching": "läuft gerade",
+    "hero.statusLive": "LIVE · sammelt Drop",
+    "hero.statusIdle": "PAUSE",
+    "hero.noActiveTarget": "Kein aktives Ziel",
+    "hero.stat.eta": "eta",
+    "hero.stat.channels": "channels",
+    "hero.stat.claimsReady": "claims bereit",
+    "hero.stat.openDrops": "offene drops",
+    "hero.stat.useInventory": "inventar nutzen",
+    "hero.stat.percentComplete": "{pct}% fertig",
+    "hero.button.claimNow": "jetzt claimen",
+    "hero.button.pause": "pause",
+    "hero.button.switchTarget": "ziel wechseln",
+    "hero.title.useInventoryToClaim": "Im Inventar claimen",
+    "hero.title.engineNotRunning": "Engine läuft nicht",
+    "hero.title.pauseEngine": "Watch-Engine pausieren",
+    "hero.title.openPrioritiesToSwitch": "Prioritäten-Ansicht öffnen, um Ziel zu wechseln",
+    "hero.title.wireLater": "Wird in einer späteren Phase verkabelt",
+
+    // queue.* — new namespace, QueuePanel
+    "queue.header": "queue · als nächstes",
+    "queue.manage": "verwalten →",
+    "queue.empty": "keine drops in der queue",
+    "queue.table.dropGame": "drop · spiel",
+    "queue.table.watched": "geschaut",
+    "queue.table.progress": "fortschritt",
+    "queue.table.status": "status",
+    "queue.pill.live": "live",
+    "queue.pill.queued": "queue",
+
+    // activity.* — new namespace, ActivityPanel
+    "activity.header": "letzte aktivität",
+    "activity.empty": "noch keine claims",
+    "activity.claimedPrefix": "Eingesammelt:",
+    "activity.recently": "vor kurzem",
+
+    // engine.* — new namespace, EnginePanel (Overview)
+    "engine.header": "engine",
+    "engine.row.watchCycle": "watch_cycle",
+    "engine.row.lastRefresh": "last_refresh",
+    "engine.row.cadence": "cadence",
+    "engine.row.uptime": "uptime",
+
+    // attention.* — new namespace, AttentionStrip
+    "attention.claimReady": "{count} claim bereit",
+    "attention.claimsReady": "{count} claims bereit",
+    "attention.watchError": "watch-fehler",
+    "attention.noChannels": "keine channels",
+    "attention.trackerLabel": "tracker {state}",
+
+    // inventory.filter.* — InventoryFilterStrip chips (new keys only; all/upcoming/notLinked/expired already defined above)
+    "inventory.filter.aria": "Inventar-Filter",
+    "inventory.filter.priority": "priorität",
+    "inventory.filter.live": "live",
+    "inventory.filter.claimed": "geclaimt",
+
+    // inventory.header.* — InventoryHeader
+    "inventory.header.title": "Inventar",
+    "inventory.header.searchPlaceholder": "drops suchen…",
+    "inventory.header.allGames": "Alle Spiele",
+    "inventory.header.refreshTitle": "Inventar aktualisieren",
+    "inventory.header.refreshing": "lade",
+    "inventory.header.refresh": "aktualisieren",
+    "inventory.header.linkAccount": "account verknüpfen",
+    "inventory.header.dropsNeedLink.one": "{count} drop braucht Account-Link",
+    "inventory.header.dropsNeedLink.other": "{count} drops brauchen Account-Link",
+    "inventory.header.countOf.one": "{shown} von {total} drop",
+    "inventory.header.countOf.other": "{shown} von {total} drops",
+
+    // inventory.drawer.* — InventoryDrawer
+    "inventory.drawer.title": "drop-details",
+    "inventory.drawer.close": "Schließen",
+    "inventory.drawer.closeAria": "Drawer schließen",
+    "inventory.drawer.progress": "fortschritt",
+    "inventory.drawer.blocked": "blockiert",
+    "inventory.drawer.campaign": "kampagne",
+    "inventory.drawer.starts": "start",
+    "inventory.drawer.ends": "ende",
+    "inventory.drawer.watchedRequired": "geschaut · benötigt",
+    "inventory.drawer.addToPriorities": "{game} zu Prioritäten",
+    "inventory.drawer.noActions": "keine Aktionen verfügbar",
+
+    // control.engineStatus.* — EngineStatusPanel hardcoded remnants
+    "control.engineStatus.header": "engine-status",
+    "control.engineStatus.why": "warum",
+    "control.engineStatus.next": "nächstes",
+    "control.engineStatus.detail.target": "ziel",
+    "control.engineStatus.detail.suppression": "unterdrückt",
+    "control.engineStatus.detail.cooldowns": "cooldowns",
+    "control.engineStatus.detail.allowlist": "allowlist",
+    "control.engineStatus.detail.noProgress": "kein fortschritt",
+
+    // control.activeSession.* — ActiveSessionPanel
+    "control.activeSession.nowWatching": "läuft gerade",
+    "control.activeSession.noActiveSession": "keine aktive session",
+    "control.activeSession.lastPing": "letzter ping",
+    "control.activeSession.loading": "lade…",
+    "control.activeSession.noStream": "kein stream",
+    "control.activeSession.live": "live",
+    "control.activeSession.paused": "pausiert",
+    "control.activeSession.activeDrop": "aktiver drop",
+    "control.activeSession.watchedRequiredEta": "{watched} geschaut · {required} benötigt · eta {eta}",
+    "control.activeSession.watchedRequired": "{watched} geschaut · {required} benötigt",
+    "control.activeSession.noFarmable": "kein farmbarer drop auf diesem channel",
+    "control.activeSession.engineIdle": "engine im leerlauf",
+    "control.activeSession.viewers": "viewer",
+
+    // control.channelGrid.* — ChannelGridPanel
+    "control.channelGrid.header": "live channels",
+    "control.channelGrid.refreshTitle": "Channel-Liste aktualisieren",
+    "control.channelGrid.refresh": "aktualisieren",
+    "control.channelGrid.noTarget": "wähle ein Ziel-Spiel in Prioritäten, um live channels zu sehen",
+    "control.channelGrid.watchingPill": "watching",
+
+    // control.campaignsPanel.* — CampaignsPanel
+    "control.campaignsPanel.empty": "keine aktiven Kampagnen",
+    "control.campaignsPanel.header": "kampagnen",
+    "control.campaignsPanel.status.claimed": "geclaimt",
+    "control.campaignsPanel.status.blocked": "blockiert",
+    "control.campaignsPanel.status.live": "live",
+    "control.campaignsPanel.status.queued": "queue",
+    "control.campaignsPanel.footerTotal": "gesamt",
+    "control.campaignsPanel.footerDrops.one": "{count} drop",
+    "control.campaignsPanel.footerDrops.other": "{count} drops",
+
+    // priorities.row.*Aria — PriorityRow drag/remove aria
+    "priorities.row.dragAria": "{game} ziehen",
+    "priorities.row.removeAria": "{game} entfernen",
   },
 };
 

--- a/src/renderer/shared/i18n.tsx
+++ b/src/renderer/shared/i18n.tsx
@@ -894,6 +894,28 @@ const translations: Translations = {
     // priorities.row.*Aria — PriorityRow drag/remove aria
     "priorities.row.dragAria": "Drag {game}",
     "priorities.row.removeAria": "Remove {game}",
+
+    // priorities.header.* — PriorityHeader strings
+    "priorities.header.rankedCount.one": "{count} game ranked",
+    "priorities.header.rankedCount.other": "{count} games ranked",
+    "priorities.header.watchingNow": "watching {game}",
+    "priorities.header.modeStrict": "strict mode",
+    "priorities.header.modeFlexible": "flexible mode",
+    "priorities.header.liveTotalSub": "live / total",
+    "priorities.header.position": "position {rank}",
+
+    // priorities.list.* — PriorityList empty state strings
+    "priorities.list.empty": "no games prioritized yet",
+    "priorities.list.emptyHint": "add a game from the panel on the left",
+
+    // priorities.add.* — PriorityAddPanel strings
+    "priorities.add.fromDropsTitle": "add from your drops",
+    "priorities.add.fromDropsHint": "pick a game that currently has live drops",
+    "priorities.add.selectPlaceholder": "select a game…",
+    "priorities.add.addButton": "add",
+    "priorities.add.manualHint": "type any game name, even ones with no live drops yet",
+    "priorities.add.manualPlaceholder": "game name…",
+    "priorities.add.strictLabel": "strict priority order",
   },
   de: {
     "app.name": "DropPilot",
@@ -1778,6 +1800,28 @@ const translations: Translations = {
     // priorities.row.*Aria — PriorityRow drag/remove aria
     "priorities.row.dragAria": "{game} ziehen",
     "priorities.row.removeAria": "{game} entfernen",
+
+    // priorities.header.* — PriorityHeader strings
+    "priorities.header.rankedCount.one": "{count} Game eingereiht",
+    "priorities.header.rankedCount.other": "{count} Games eingereiht",
+    "priorities.header.watchingNow": "schaut {game}",
+    "priorities.header.modeStrict": "strikter Modus",
+    "priorities.header.modeFlexible": "flexibler Modus",
+    "priorities.header.liveTotalSub": "live / gesamt",
+    "priorities.header.position": "position {rank}",
+
+    // priorities.list.* — PriorityList empty state strings
+    "priorities.list.empty": "noch keine Games priorisiert",
+    "priorities.list.emptyHint": "füge ein Game über das Panel links hinzu",
+
+    // priorities.add.* — PriorityAddPanel strings
+    "priorities.add.fromDropsTitle": "aus Drops hinzufügen",
+    "priorities.add.fromDropsHint": "wähle ein Game, das gerade aktive Drops hat",
+    "priorities.add.selectPlaceholder": "Game auswählen…",
+    "priorities.add.addButton": "hinzufügen",
+    "priorities.add.manualHint": "beliebigen Game-Namen eingeben, auch ohne aktive Drops",
+    "priorities.add.manualPlaceholder": "Game-Name…",
+    "priorities.add.strictLabel": "strikte Prioritätsreihenfolge",
   },
 };
 


### PR DESCRIPTION
## Summary

Sweeps every remaining hardcoded English literal out of the Phase 2-5 components (Overview, Inventory, Control, Priority) into the existing `useI18n` translation system. Phase 8 covered Settings; Phase 9 covers everything else built during the overhaul.

After this lands, **all shipped UI text is bilingual** (EN + DE) outside of:
- Generic shadcn primitives (which receive translated strings from consumers)
- `formatters.ts` time fragments ("5m ago" etc., locked out for v1 — ICU plurals deferred)
- 2 minor aria-labels in PriorityAddPanel ("Add from drops" / "Add game manually") — noted by implementer

**Stacked on:** PR #28 (Phase 8 Settings i18n + tracker). Auto-retargets to main after upstream merges.

## What changed

### New i18n keys (`src/renderer/shared/i18n.tsx`)

| Namespace | New keys | Notes |
|---|---|---|
| `hero.*` additions | ~18 | nowWatching, statusLive/Idle, stat.*, button.*, title.* |
| `queue.*` | 9 | new namespace — QueuePanel header, table, pills |
| `activity.*` | 4 | new namespace — ActivityPanel header/empty/prefix |
| `engine.*` | 5 | new namespace — EnginePanel header + row keys |
| `attention.*` | 5 | new namespace — AttentionStrip claim ready/error/tracker |
| `inventory.filter.*` | 4 | aria, priority, live, claimed (other 4 reuse existing) |
| `inventory.header.*` | 12 | title, search, refresh, link, plural counts |
| `inventory.drawer.*` | 11 | title, close, details, prio button, etc. |
| `control.engineStatus.*` | 8 | header, why, next, detail row labels |
| `control.activeSession.*` | 13 | now watching, ping, live/paused, drop labels, viewers |
| `control.channelGrid.*` | 5 | header, refresh, noTarget, watching pill |
| `control.campaignsPanel.*` | 9 | header, empty, status pills, footer |
| `priorities.row.*` | 2 | drag/remove aria templates |
| `priorities.header.*` | 7 | rankedCount plural, watchingNow, mode pills, queue, position |
| `priorities.list.*` | 2 | empty + emptyHint |
| `priorities.add.*` | 7 | from-drops title/hint, placeholders, button, manual hint/placeholder, strict label |

**Total: ~120 new key-value pairs (EN + DE = ~240 lines added).**

### Components wired (15 files)

**Overview (5):**
- `HeroPanel.tsx` — 15 strings
- `QueuePanel.tsx` — 8 strings
- `ActivityPanel.tsx` — 4 strings
- `EnginePanel.tsx` — 5 strings (refactored `rows` array to separate `id` / `label`)
- `AttentionStrip.tsx` — 5 strings (with `count === 1` plural branching)

**Inventory (4):**
- `InventoryFilterStrip.tsx` — 8 chip labels (moved CHIP_DEFS into useMemo)
- `InventoryHeader.tsx` — 11 strings (with plurals for drop counts)
- `InventoryTable.tsx` — 4 column headers (reuses `queue.table.*`)
- `InventoryDrawer.tsx` — 12 strings

**Control (4):**
- `EngineStatusPanel.tsx` — 8 remaining strings (Phase 8 had already wired some)
- `ActiveSessionPanel.tsx` — 11 strings (with eta/no-eta key branching)
- `ChannelGridPanel.tsx` — 5 strings
- `CampaignsPanel.tsx` — 8 strings (with plural footer)

**Priority (4):**
- `PriorityRow.tsx` — 6 strings (STATE_LABEL moved into useMemo, drag/remove aria)
- `PriorityHeader.tsx` — 7 strings (rankedCount plural, modes, queue, position)
- `PriorityList.tsx` — 2 empty-state strings
- `PriorityAddPanel.tsx` — 10 strings (reuses 5 existing `priorities.*` keys)

### Reuse highlights
- `queue.table.*` keys shared with InventoryTable (intentional column-header sharing)
- `priorities.queueHealth`, `priorities.addEmpty`, `priorities.manualTitle`, `priorities.ruleStrictHint`, `priorities.ruleFlexibleHint` reused in PriorityAddPanel
- `priorities.state.*` reused for PriorityRow STATE_LABEL
- Phase 8's `control.tracker.*` keys remain untouched

## Verification

- Lint: 0 errors, 4 pre-existing warnings unchanged
- Tests: 214/214 passing
- TSC: only the ~18-error pre-existing baseline in unrelated files (DebugView, useInventory, useChannels, etc.)
- Build: clean

## Out of scope (deferred)

- **HeroPanel claim-now button wiring** — needs claim engine surfacing through useAppModel (no `claimAny()` API exists in useInventory today). Audit confirmed it requires 3-layer hook surgery; reserved for Phase 10 with proper investigation + plan.
- `formatters.ts` "5m ago"/"2h ago" fragments — embedded in template literals, would need ICU plurals to translate cleanly. Locked out for v1.
- 2 aria-labels in PriorityAddPanel skipped by implementer (low priority)
- Light-mode visual polish — separate phase
- `--dp-*` token rename — separate phase

## Test plan

- [ ] Open Settings → toggle language between English / Deutsch
- [ ] Navigate to Overview — HeroPanel buttons, stat labels, queue, activity, engine, attention strip all reflect chosen language
- [ ] Navigate to Inventory — filter chips, search placeholder, header counts, drawer details all translated
- [ ] Navigate to Control — engine status detail rows, active session labels, channel grid, campaigns panel all translated
- [ ] Navigate to Priorities — header counts, mode pills, list empty state, add panel labels all translated
- [ ] All pluralized strings (counts) show correct singular/plural form based on count
- [ ] No console warnings about missing i18n keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)