### PR TITLE
Phase 12 — Fix live-data bug (double-count + static progress bar)

### DIFF
--- a/src/renderer/features/control/ControlView.tsx
+++ b/src/renderer/features/control/ControlView.tsx
@@ -265,8 +265,13 @@ export function ControlView(props: ControlProps) {
         activeLoginMismatch={state.activeLoginMismatch}
         activeDropTitle={activeDropInfo?.title ?? null}
         activeDropEarnedMinutes={
+          // Use raw earnedMinutes (last inventory snapshot) + the live-ticking
+          // activeElapsedMinutesRaw (seconds since progressAnchorAt, updated 1s).
+          // Do NOT use virtualEarned here — it already bakes in elapsed time
+          // since the anchor, which would double-count when added to
+          // activeElapsedMinutesRaw (both measure from the same base).
           activeDropInfo
-            ? activeDropInfo.virtualEarned + state.liveProgress.activeElapsedMinutesRaw
+            ? activeDropInfo.earnedMinutes + state.liveProgress.activeElapsedMinutesRaw
             : 0
         }
         activeDropRequiredMinutes={activeDropInfo?.requiredMinutes ?? 0}

--- a/src/renderer/shared/hooks/inventory/useTargetDrops.test.ts
+++ b/src/renderer/shared/hooks/inventory/useTargetDrops.test.ts
@@ -140,7 +140,9 @@ describe("computeTargetDrops", () => {
       now,
     });
     expect(result.liveDeltaApplied).toBe(10);
-    expect(result.targetProgress).toBe(0);
+    // targetProgress now includes liveDeltaApplied so the % bar advances
+    // between inventory polls. 10 live minutes / 60 required = 16.67% → 17.
+    expect(result.targetProgress).toBe(17);
     expect(result.canWatchTarget).toBe(true);
   });
 

--- a/src/renderer/shared/hooks/inventory/useTargetDrops.ts
+++ b/src/renderer/shared/hooks/inventory/useTargetDrops.ts
@@ -1,7 +1,8 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { InventoryDrop, InventoryDropCollection } from "@renderer/shared/domain/dropDomain";
 import { canEarnDrop, hasHardWatchingBlockers } from "@renderer/shared/domain/inventory";
 import type { InventoryItem, WatchingState } from "@renderer/shared/types";
+import { useInterval } from "@renderer/shared/hooks/useInterval";
 
 type WithCategory = { item: InventoryItem; category: string };
 
@@ -261,8 +262,13 @@ export function computeTargetDrops({
     activeDrop && canPredictActiveDropProgress
       ? Math.min(liveDeltaMinutes, Math.max(0, activeDropRequired - activeDropEarned))
       : 0;
+  // Include the live-ticking delta from the active drop so the percentage
+  // advances between inventory polls (which can be ~1h apart).
   const targetProgress = totalRequiredMinutes
-    ? Math.min(100, Math.round((totalEarnedMinutes / totalRequiredMinutes) * 100))
+    ? Math.min(
+        100,
+        Math.round(((totalEarnedMinutes + liveDeltaApplied) / totalRequiredMinutes) * 100),
+      )
     : 0;
   const activeDropVirtualEarned = activeDrop
     ? Math.min(activeDropRequired, activeDropEarned + liveDeltaApplied)
@@ -316,6 +322,14 @@ export function useTargetDrops({
   inventoryFetchedAt,
   progressAnchorByDropId,
 }: Params): TargetDropsResult {
+  // Tick `now` every second while the user is watching the target game so
+  // targetProgress, liveDeltaApplied, virtualEarned, and activeDropEta stay
+  // live between inventory polls. When not watching the target, no interval
+  // runs and `now` stays static (cheap).
+  const isLiveActive = Boolean(watching && watching.game === targetGame);
+  const [nowMs, setNowMs] = useState<number>(() => Date.now());
+  useInterval(() => setNowMs(Date.now()), 1000, isLiveActive);
+
   return useMemo(
     () =>
       computeTargetDrops({
@@ -327,6 +341,7 @@ export function useTargetDrops({
         watching,
         inventoryFetchedAt,
         progressAnchorByDropId,
+        now: isLiveActive ? nowMs : undefined,
       }),
     [
       allowWatching,
@@ -337,6 +352,8 @@ export function useTargetDrops({
       targetGame,
       watching,
       withCategories,
+      isLiveActive,
+      nowMs,
     ],
   );
 }


### PR DESCRIPTION
## Summary

Two related fixes that resolve the user-reported "everything feels static" complaint about Overview / Inventory / Control views during a watch session.

**Stacked on:** PR #31 (Phase 11 light-mode polish).

## The bugs

### Bug 1 — Active drop progress double-counts elapsed time

`ControlView.tsx:269` was passing:
```ts
activeDropInfo.virtualEarned + state.liveProgress.activeElapsedMinutesRaw
```

Both values measure elapsed time from the same `progressAnchorAt` base:
- `virtualEarned` = `earnedMinutes + liveDeltaApplied` where `liveDeltaApplied = (computeTime - anchorAt) / 60000`
- `activeElapsedMinutesRaw` = `(progressNow - anchorAt) / 60000`

Adding them doubled the elapsed minutes immediately. The progress bar in the Active Session panel jumped to ~2× the correct value the moment a watch started, then continued ticking incorrectly from there.

**Fix:** pass `earnedMinutes` (raw, from last inventory snapshot) + `activeElapsedMinutesRaw` (which ticks every second). Single source of truth for the live delta, no double-count.

### Bug 2 — `targetProgress` was static between inventory polls

`useTargetDrops.computeTargetDrops` was computing the Overview progress bar percentage as:
```ts
targetProgress = totalEarnedMinutes / totalRequiredMinutes * 100
```

`totalEarnedMinutes` is only updated when inventory is re-fetched, which the cadence floor caps at **once per hour**. Result: the Overview progress bar didn't advance for up to an hour even while actively watching. PubSub `drop-progress` events would update inventory inline, but between those events the bar was frozen.

**Fix:**
1. Include `liveDeltaApplied` in the numerator: `((totalEarnedMinutes + liveDeltaApplied) / totalRequiredMinutes) * 100`
2. Add an internal `useInterval` to `useTargetDrops` that ticks `nowMs` every second while `watching.game === targetGame`. This propagates the live delta refresh to every consumer (Overview, HeroPanel, ControlView).

When not watching the target game, no interval runs — zero cost when idle.

## Files changed

- `src/renderer/features/control/ControlView.tsx` — single-line fix + design comment
- `src/renderer/shared/hooks/inventory/useTargetDrops.ts` — live `nowMs` ticker + targetProgress formula
- `src/renderer/shared/hooks/inventory/useTargetDrops.test.ts` — updated the test that asserted the old (buggy) behavior

## Verification

- Tests: 214/214 passing
- Lint: 0 errors, 4 pre-existing warnings unchanged
- TSC: pre-existing baseline only
- Build: clean

## Cadence note

The `MIN_REFRESH_MS = 1h` floor stays in place — PubSub `drop-progress` events are the primary live channel between inventory refreshes, and now that the local interpolation is correct (no double-count, live targetProgress), the UI should feel live even between PubSub pushes.

If PubSub isn't connected or fails, the UI still ticks locally up to the drop's required minutes (capped per drop), so it degrades gracefully.

## Test plan

- [ ] Open the app, start watching a stream of the target game with an in-progress drop
- [ ] Overview view: HeroPanel progress bar % advances at ~1%/min (depending on drop length)
- [ ] HeroPanel ETA countdown ticks every second (already worked, regression check)
- [ ] Control view → Active Session panel: progress bar advances at ~1%/min, does NOT double-count
- [ ] Hour-long drop with 0 earned: after 10 minutes watching, both Overview (~17%) and Control (~17%) should show consistent percentages
- [ ] Stop watching → ticker stops (verified via no extra renders in React profiler)

🤖 Generated with [Claude Code](https://claude.com/claude-code)