### PR TITLE
Fix — Sticky chrome (Titlebar/AppNav/Statusbar stay pinned on scroll)

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -162,8 +162,11 @@ function AppShell({ model }: { model: Model }) {
   );
 
   return (
+    // h-screen + overflow-hidden locks the outer shell to the viewport so the
+    // chrome strips (Titlebar / AppNav / Statusbar) stay fixed in place.
+    // The middle content area is the actual scroll container (see below).
     <div
-      className="min-h-screen flex flex-col"
+      className="h-screen overflow-hidden flex flex-col"
       style={{ background: "var(--dp-bg-app)", color: "var(--dp-text)" }}
     >
       {!isMac && (
@@ -182,7 +185,10 @@ function AppShell({ model }: { model: Model }) {
         items={navItems}
         right={sessionRight}
       />
-      <div className="flex-1">
+      {/* min-h-0 is critical: flex children default to min-height:auto which
+          would prevent the inner content from shrinking below its intrinsic
+          height, so overflow-y-auto would never engage. */}
+      <div className="flex-1 min-h-0 overflow-y-auto">
         <AppContent
           navProps={navProps}
           overviewProps={overviewPropsExtended}


### PR DESCRIPTION
## Summary

Titlebar, AppNav, and Statusbar scrolled away with the page when content was longer than the viewport. Now they stay pinned in place; only the middle content scrolls.

**Stacked on:** PR #32 (Phase 12 live-data fix).

## The problem

`AppShell` used `min-h-screen flex flex-col` with no overflow constraint. When `AppContent` rendered content taller than the viewport, the document body itself scrolled — taking the chrome strips with it.

## The fix

Two coordinated CSS changes on the outer shell:

1. `min-h-screen` → `h-screen overflow-hidden` — locks the outer to exactly the viewport height and prevents body scroll
2. Inner content `<div className="flex-1">` → `<div className="flex-1 min-h-0 overflow-y-auto">` — makes the middle area the actual scroll container

The `min-h-0` is critical: flex children default to `min-height: auto`, which would prevent the inner div from shrinking below its intrinsic content height. Without it, the `overflow-y-auto` would never engage because the flex item would always expand to fit its content.

## Files changed

- `src/renderer/App.tsx` — 1 className update + 1 className update (+ explanatory comments)

## Verification

- Tests: 214/214 passing
- Lint: 0 errors
- TSC: pre-existing baseline
- Build: clean

## Test plan

- [ ] Open Overview / Inventory / Control / Settings → scroll the content area
- [ ] Titlebar stays pinned at top (Windows; Mac uses native chrome anyway)
- [ ] AppNav stays pinned below the titlebar
- [ ] Statusbar stays pinned at bottom
- [ ] No double-scrollbar (page-level + content-level)
- [ ] Long Settings pages (Engine, Alerts) scroll smoothly inside the inner container

🤖 Generated with [Claude Code](https://claude.com/claude-code)