### PR TITLE
Phase 13 — Custom Titlebar with Lucide window controls

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -131,14 +131,10 @@ function createWindow(startHidden = false): BrowserWindow {
     title: "DropPilot",
     show: !startHidden,
     autoHideMenuBar: !isMac,
+    // Windows: hide the OS title bar entirely; the renderer Titlebar draws
+    // its own min/max/close buttons (with Lucide icons + Pro Console styling).
+    // macOS: keep native chrome (traffic lights).
     titleBarStyle: isMac ? "default" : "hidden",
-    titleBarOverlay: isMac
-      ? undefined
-      : {
-          color: "#08090b",       // matches --dp-bg-chrome (dark titlebar bg)
-          symbolColor: "#9aa0a8", // matches --dp-text-dim (icon stroke color)
-          height: 36,             // matches the Titlebar component h-9 (36px)
-        },
     frame: isMac,
     backgroundColor: "#040814",
     webPreferences: {
@@ -184,6 +180,16 @@ function createWindow(startHidden = false): BrowserWindow {
       win.hide();
     });
   }
+
+  // Push maximize-state changes to the renderer so the custom Titlebar can
+  // swap its maximize/restore icon. Fires on the OS-level maximize/unmaximize
+  // events (which include double-click on titlebar, snap-zones, etc.).
+  const sendMaxState = () => {
+    if (win.isDestroyed()) return;
+    win.webContents.send("app/maximizedChange", { isMaximized: win.isMaximized() });
+  };
+  win.on("maximize", sendMaxState);
+  win.on("unmaximize", sendMaxState);
 
   return win;
 }

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -376,6 +376,11 @@ export function registerIpcHandlers(deps: {
     return resetStats();
   });
 
+  ipcMain.handle("app/isMaximized", async (event) => {
+    const win = BrowserWindow.fromWebContents(event.sender);
+    return { ok: true, isMaximized: !!win?.isMaximized() };
+  });
+
   ipcMain.handle(
     "app/windowControl",
     async (

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -141,6 +141,12 @@ const api = {
   app: {
     windowControl: (action: "minimize" | "maximize" | "restore" | "close" | "hide-to-tray") =>
       ipcRenderer.invoke("app/windowControl", { action }),
+    isMaximized: () => ipcRenderer.invoke("app/isMaximized"),
+    onMaximizedChange: (handler: (payload: { isMaximized: boolean }) => void) => {
+      const listener = (_event: unknown, payload: { isMaximized: boolean }) => handler(payload);
+      ipcRenderer.on("app/maximizedChange", listener);
+      return () => ipcRenderer.removeListener("app/maximizedChange", listener);
+    },
     checkUpdates: () => ipcRenderer.invoke("app/checkUpdates"),
     downloadUpdate: () => ipcRenderer.invoke("app/downloadUpdate"),
     installUpdate: () => ipcRenderer.invoke("app/installUpdate"),

--- a/src/renderer/shared/components/chrome/Titlebar.tsx
+++ b/src/renderer/shared/components/chrome/Titlebar.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
 import { Logo } from "@renderer/shared/components/Logo";
 import { Pill } from "@renderer/shared/components/ui/pill";
-import { Sun, Moon, Settings } from "@renderer/shared/lib/icons";
+import { Sun, Moon, Settings, Minus, Square, Copy, X } from "@renderer/shared/lib/icons";
 import { cn } from "@renderer/shared/lib/utils";
+import { useI18n } from "@renderer/shared/i18n";
 
 export type TitlebarTheme = "light" | "dark";
 
@@ -17,8 +18,13 @@ export type TitlebarProps = {
   connectionState?: "connected" | "disconnected" | "connecting";
   apiLatencyMs?: number;
 
+  /** When false, the min/max/close window controls aren't rendered (e.g. macOS uses native chrome). */
+  showWindowControls?: boolean;
+
   className?: string;
 };
+
+const noDrag = { WebkitAppRegion: "no-drag" } as React.CSSProperties;
 
 export function Titlebar({
   title = "droppilot",
@@ -28,12 +34,51 @@ export function Titlebar({
   onSettingsClick,
   connectionState,
   apiLatencyMs,
+  showWindowControls = true,
   className,
 }: TitlebarProps) {
+  const { t } = useI18n();
+  const [isMaximized, setIsMaximized] = React.useState(false);
+
+  // Subscribe to OS-level maximize/unmaximize so the maximize/restore icon swaps
+  // when the user double-clicks the titlebar, uses snap zones, or presses
+  // Win+Up/Win+Down. Also fetch initial state once.
+  React.useEffect(() => {
+    if (!showWindowControls) return;
+    const api = window.electronAPI?.app;
+    if (!api) return;
+    let cancelled = false;
+    api.isMaximized().then((res: { ok: boolean; isMaximized?: boolean }) => {
+      if (!cancelled && res?.ok) setIsMaximized(!!res.isMaximized);
+    });
+    const unsubscribe = api.onMaximizedChange((payload: { isMaximized: boolean }) => {
+      setIsMaximized(payload.isMaximized);
+    });
+    return () => {
+      cancelled = true;
+      unsubscribe?.();
+    };
+  }, [showWindowControls]);
+
+  const sendWindowControl = React.useCallback(
+    (action: "minimize" | "maximize" | "restore" | "close") => {
+      window.electronAPI?.app?.windowControl(action);
+    },
+    [],
+  );
+
+  const handleMaxRestore = React.useCallback(() => {
+    sendWindowControl(isMaximized ? "restore" : "maximize");
+  }, [isMaximized, sendWindowControl]);
+
   return (
     <div
       className={cn(
-        "flex h-9 items-center gap-3.5 border-b border-[color:var(--dp-border)] bg-[color:var(--dp-bg-chrome)] pl-3.5 pr-[140px]",
+        "flex h-9 items-center gap-3.5 border-b border-[color:var(--dp-border)] bg-[color:var(--dp-bg-chrome)] pl-3.5",
+        // Pad-right is small when we draw our own controls (they bring their own width).
+        // When showWindowControls is off (macOS uses native traffic lights on the LEFT,
+        // not the right) keep a small uniform pad-right.
+        showWindowControls ? "pr-1" : "pr-3.5",
         "app-drag",
         className,
       )}
@@ -55,10 +100,7 @@ export function Titlebar({
       </div>
 
       {/* Center/right status */}
-      <div
-        className="ml-auto flex items-center gap-2"
-        style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
-      >
+      <div className="ml-auto flex items-center gap-2" style={noDrag}>
         {connectionState && (
           <Pill
             tone={
@@ -75,11 +117,12 @@ export function Titlebar({
         )}
         {typeof apiLatencyMs === "number" && <Pill tone="dim">api {apiLatencyMs}ms</Pill>}
 
-        {/* Icon actions — same size + tone as window controls */}
+        {/* Icon actions: theme + settings */}
         <button
           type="button"
           onClick={onThemeToggle}
-          aria-label={`Toggle theme (current: ${theme})`}
+          aria-label={t("chrome.window.themeToggle")}
+          title={t("chrome.window.themeToggle")}
           className="flex h-[26px] w-[26px] items-center justify-center rounded-[var(--dp-radius-xs)] text-[color:var(--dp-text-dimmer)] transition-colors hover:bg-[color:var(--dp-bg-elevated)] hover:text-[color:var(--dp-text-dim)]"
         >
           {theme === "dark" ? (
@@ -92,13 +135,71 @@ export function Titlebar({
           <button
             type="button"
             onClick={onSettingsClick}
-            aria-label="Open settings"
+            aria-label={t("chrome.window.openSettings")}
+            title={t("chrome.window.openSettings")}
             className="flex h-[26px] w-[26px] items-center justify-center rounded-[var(--dp-radius-xs)] text-[color:var(--dp-text-dimmer)] transition-colors hover:bg-[color:var(--dp-bg-elevated)] hover:text-[color:var(--dp-text-dim)]"
           >
             <Settings size={13} strokeWidth={1.7} />
           </button>
         )}
+
+        {/* Window controls (Windows / Linux only). macOS uses native traffic lights. */}
+        {showWindowControls && (
+          <div className="flex items-stretch ml-1.5 -mr-1 h-full" style={noDrag}>
+            <WindowButton
+              ariaLabel={t("chrome.window.minimize")}
+              onClick={() => sendWindowControl("minimize")}
+            >
+              <Minus size={13} strokeWidth={1.7} />
+            </WindowButton>
+            <WindowButton
+              ariaLabel={isMaximized ? t("chrome.window.restore") : t("chrome.window.maximize")}
+              onClick={handleMaxRestore}
+            >
+              {isMaximized ? (
+                // Copy = two offset squares (Windows restore-down convention)
+                <Copy size={12} strokeWidth={1.7} />
+              ) : (
+                <Square size={11} strokeWidth={1.8} />
+              )}
+            </WindowButton>
+            <WindowButton
+              ariaLabel={t("chrome.window.close")}
+              onClick={() => sendWindowControl("close")}
+              danger
+            >
+              <X size={14} strokeWidth={1.8} />
+            </WindowButton>
+          </div>
+        )}
       </div>
     </div>
+  );
+}
+
+type WindowButtonProps = {
+  ariaLabel: string;
+  onClick: () => void;
+  children: React.ReactNode;
+  /** Red hover treatment for the close button (Windows convention). */
+  danger?: boolean;
+};
+
+function WindowButton({ ariaLabel, onClick, children, danger }: WindowButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={ariaLabel}
+      title={ariaLabel}
+      className={cn(
+        "flex h-full w-[46px] items-center justify-center text-[color:var(--dp-text-dim)] transition-colors",
+        danger
+          ? "hover:bg-[#e81123] hover:text-white"
+          : "hover:bg-[color:var(--dp-bg-elevated)] hover:text-[color:var(--dp-text)]",
+      )}
+    >
+      {children}
+    </button>
   );
 }

--- a/src/renderer/shared/components/chrome/Titlebar.tsx
+++ b/src/renderer/shared/components/chrome/Titlebar.tsx
@@ -143,9 +143,12 @@ export function Titlebar({
           </button>
         )}
 
-        {/* Window controls (Windows / Linux only). macOS uses native traffic lights. */}
+        {/* Window controls (Windows / Linux only). macOS uses native traffic lights.
+            self-stretch overrides the parent's items-center so this wrapper
+            spans the full 36px titlebar height; each button below then uses
+            h-full to render a proper 46x36 hit-target like the OS controls. */}
         {showWindowControls && (
-          <div className="flex items-stretch ml-1.5 -mr-1 h-full" style={noDrag}>
+          <div className="flex items-stretch self-stretch ml-1.5 -mr-1" style={noDrag}>
             <WindowButton
               ariaLabel={t("chrome.window.minimize")}
               onClick={() => sendWindowControl("minimize")}

--- a/src/renderer/shared/i18n.tsx
+++ b/src/renderer/shared/i18n.tsx
@@ -64,6 +64,13 @@ const translations: Translations = {
     "nav.settings": "Settings",
     "nav.settings.caption": "Automatisierung & Backup",
 
+    "chrome.window.minimize": "Minimize",
+    "chrome.window.maximize": "Maximize",
+    "chrome.window.restore": "Restore",
+    "chrome.window.close": "Close",
+    "chrome.window.themeToggle": "Toggle theme",
+    "chrome.window.openSettings": "Open settings",
+
     "session.title": "Session",
     "session.connected": "Logged in",
     "session.disconnected": "Not logged in",
@@ -981,6 +988,13 @@ const translations: Translations = {
     "nav.debug.caption": "Live-Logs & Status",
     "nav.settings": "Einstellungen",
     "nav.settings.caption": "Automation & Backup",
+
+    "chrome.window.minimize": "Minimieren",
+    "chrome.window.maximize": "Maximieren",
+    "chrome.window.restore": "Wiederherstellen",
+    "chrome.window.close": "Schließen",
+    "chrome.window.themeToggle": "Theme umschalten",
+    "chrome.window.openSettings": "Einstellungen öffnen",
 
     "session.title": "Session",
     "session.connected": "Eingeloggt",

--- a/src/renderer/shared/lib/icons.ts
+++ b/src/renderer/shared/lib/icons.ts
@@ -17,6 +17,7 @@ export {
   Monitor,
   Minus,
   Square,
+  Copy,
   X,
   ChevronDown,
   ChevronUp,


### PR DESCRIPTION
## Summary

Switches from Electron's native Windows `titleBarOverlay` (which drew min/max/close in OS chrome) to a custom Titlebar that draws its own controls in React. Now uses Lucide icons + Pro Console styling that matches the rest of the chrome.

**Stacked on:** PR #33 (chrome sticky layout fix).

## What changed

### Main process (`src/main/index.ts`)
- Removed the `titleBarOverlay` block entirely. `titleBarStyle: "hidden"` + `frame: false` stays for Windows; macOS keeps native chrome.
- New `win.on("maximize"|"unmaximize")` listener that pushes `app/maximizedChange` IPC events to the renderer so the custom icon swaps when OS-level maximize state changes (double-click titlebar, snap zones, Win+Up/Down).

### Main IPC (`src/main/ipc/index.ts`)
- New `app/isMaximized` invoke handler for initial state query.
- Existing `app/windowControl` handler unchanged (was already wired for minimize/maximize/restore/close/hide-to-tray).

### Preload (`src/preload/index.ts`)
- New `electronAPI.app.isMaximized()` — Promise<{ ok, isMaximized }>.
- New `electronAPI.app.onMaximizedChange(handler)` — subscribes to push events, returns unsubscribe fn.

### Renderer Titlebar (`src/renderer/shared/components/chrome/Titlebar.tsx`)
- Adds 3 window control buttons (minimize, maximize/restore, close) rendered RIGHT-ALIGNED after the existing theme/settings icon row.
- Subscribes to `onMaximizedChange` on mount + does initial `isMaximized()` query so the icon swaps correctly even if the user maximized via OS shortcut.
- Close button: red hover `#e81123` with white icon (Windows convention).
- All buttons have `WebkitAppRegion: no-drag` so clicks aren't eaten by the draggable region.
- `pr-[140px]` (reserved space for native controls) dropped to `pr-1` (controls bring their own width).
- Adds `showWindowControls?: boolean` prop (default true) so future macOS or showcase use cases can opt out. App.tsx already gates rendering with `!isMac`.

### Icons (`src/renderer/shared/lib/icons.ts`)
- Adds `Copy` to the central icon barrel (used for the restore-down icon per Windows convention — two overlapping squares).

### i18n
- Adds 6 new `chrome.window.*` keys (EN + DE):
  - `minimize` / `maximize` / `restore` / `close` / `themeToggle` / `openSettings`
- Used for both `aria-label` (screen readers) and `title` (hover tooltips) on every control.

## Verification

- Tests: 214/214 passing
- Lint: 0 errors, 4 pre-existing warnings unchanged
- TSC: pre-existing baseline only
- Build: clean (preload 2.55 KB)

## Test plan

- [ ] Launch app on Windows → Titlebar shows 3 custom buttons on the right (min, max, close)
- [ ] Click minimize → window minimizes to taskbar
- [ ] Click maximize → window maximizes, icon swaps to restore (two squares)
- [ ] Click restore → window unmaximizes, icon swaps back to single square
- [ ] Double-click empty area of titlebar → maximize toggles AND icon stays in sync
- [ ] Press Win+Up → maximize, icon syncs
- [ ] Press Win+Down → unmaximize, icon syncs
- [ ] Hover close button → red bg with white X (Windows convention)
- [ ] Hover other buttons → subtle elevated bg
- [ ] Click close → window closes (note: tray close-intercept is Phase 14)
- [ ] Switch language to Deutsch → all tooltips translated (Minimieren / Maximieren / etc.)
- [ ] macOS (if testable) → no custom controls (gated by !isMac in App.tsx)

🤖 Generated with [Claude Code](https://claude.com/claude-code)