### PR TITLE
Fix — tighten AccentPicker layout (stacked SettingRow + inline reset)

### DIFF
--- a/src/renderer/features/settings/AccentPicker.tsx
+++ b/src/renderer/features/settings/AccentPicker.tsx
@@ -39,91 +39,94 @@ export function AccentPicker({ accent, setAccent }: AccentPickerProps) {
   const customColorValue = accent && /^#[0-9a-fA-F]{6}$/.test(accent) ? accent : "#a78bfa";
 
   return (
-    <div className="flex flex-col gap-3">
-      {/* Preset swatches */}
-      <div className="flex flex-wrap items-center gap-2">
-        {PRESETS.map((preset) => {
-          const isActive = preset.id === activePresetId;
-          const name = t(preset.nameKey);
-          return (
-            <button
-              key={preset.id}
-              type="button"
-              onClick={() => setAccent(preset.color)}
-              aria-label={t("settings.row.accent.swatchAria", { name })}
-              aria-pressed={isActive}
-              title={name}
-              className={cn(
-                "relative inline-flex h-8 w-8 items-center justify-center rounded-full",
-                "transition-transform hover:scale-110",
-                isActive
-                  ? "ring-2 ring-offset-2 ring-offset-[color:var(--dp-bg-elevated)]"
-                  : "ring-1 ring-[color:var(--dp-border)]",
-              )}
-              style={{
-                background: preset.color,
-                // The active ring uses the swatch color so the indicator matches what got picked.
-                ...(isActive ? ({ "--tw-ring-color": preset.color } as React.CSSProperties) : {}),
-              }}
-            >
-              {isActive && (
-                <Check
-                  size={14}
-                  strokeWidth={2.4}
-                  className="text-[color:var(--dp-bg-app)]"
-                  aria-hidden="true"
-                />
-              )}
-            </button>
-          );
-        })}
+    // Single-row layout: 8 preset swatches + custom-color swatch + optional reset
+    // button. With SettingRow's `stacked` variant the picker spans the full
+    // panel width so it doesn't wrap unless the window is very narrow.
+    <div className="flex flex-wrap items-center gap-2">
+      {PRESETS.map((preset) => {
+        const isActive = preset.id === activePresetId;
+        const name = t(preset.nameKey);
+        return (
+          <button
+            key={preset.id}
+            type="button"
+            onClick={() => setAccent(preset.color)}
+            aria-label={t("settings.row.accent.swatchAria", { name })}
+            aria-pressed={isActive}
+            title={name}
+            className={cn(
+              "relative inline-flex h-7 w-7 items-center justify-center rounded-full",
+              "transition-transform hover:scale-110",
+              isActive
+                ? "ring-2 ring-offset-2 ring-offset-[color:var(--dp-bg-elevated)]"
+                : "ring-1 ring-[color:var(--dp-border)]",
+            )}
+            style={{
+              background: preset.color,
+              // The active ring uses the swatch color so the indicator matches what got picked.
+              ...(isActive ? ({ "--tw-ring-color": preset.color } as React.CSSProperties) : {}),
+            }}
+          >
+            {isActive && (
+              <Check
+                size={12}
+                strokeWidth={2.4}
+                className="text-[color:var(--dp-bg-app)]"
+                aria-hidden="true"
+              />
+            )}
+          </button>
+        );
+      })}
 
-        {/* Custom color input — native browser color picker. */}
-        <label
-          className={cn(
-            "relative inline-flex h-8 w-8 items-center justify-center rounded-full cursor-pointer overflow-hidden",
-            "transition-transform hover:scale-110",
-            isCustom
-              ? "ring-2 ring-offset-2 ring-offset-[color:var(--dp-bg-elevated)]"
-              : "ring-1 ring-[color:var(--dp-border)]",
-          )}
-          style={{
-            // Conic gradient hints at "any color" while still showing the current pick when isCustom.
-            background: isCustom
-              ? customColorValue
-              : "conic-gradient(from 0deg, #fb7185, #fbbf24, #34d399, #38bdf8, #818cf8, #a78bfa, #fb7185)",
-            ...(isCustom
-              ? ({ "--tw-ring-color": customColorValue } as React.CSSProperties)
-              : {}),
-          }}
-          title={t("settings.row.accent.customAria")}
+      {/* Custom color input — native browser color picker. */}
+      <label
+        className={cn(
+          "relative inline-flex h-7 w-7 items-center justify-center rounded-full cursor-pointer overflow-hidden",
+          "transition-transform hover:scale-110",
+          isCustom
+            ? "ring-2 ring-offset-2 ring-offset-[color:var(--dp-bg-elevated)]"
+            : "ring-1 ring-[color:var(--dp-border)]",
+        )}
+        style={{
+          // Conic gradient hints at "any color" while still showing the current pick when isCustom.
+          background: isCustom
+            ? customColorValue
+            : "conic-gradient(from 0deg, #fb7185, #fbbf24, #34d399, #38bdf8, #818cf8, #a78bfa, #fb7185)",
+          ...(isCustom ? ({ "--tw-ring-color": customColorValue } as React.CSSProperties) : {}),
+        }}
+        title={t("settings.row.accent.customAria")}
+        aria-label={t("settings.row.accent.customAria")}
+      >
+        <input
+          type="color"
+          value={customColorValue}
+          onChange={(e) => setAccent(e.target.value)}
+          className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
           aria-label={t("settings.row.accent.customAria")}
-        >
-          <input
-            type="color"
-            value={customColorValue}
-            onChange={(e) => setAccent(e.target.value)}
-            className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
-            aria-label={t("settings.row.accent.customAria")}
+        />
+        {isCustom && (
+          <Check
+            size={12}
+            strokeWidth={2.4}
+            className="text-[color:var(--dp-bg-app)] relative z-10"
+            aria-hidden="true"
           />
-          {isCustom && (
-            <Check
-              size={14}
-              strokeWidth={2.4}
-              className="text-[color:var(--dp-bg-app)] relative z-10"
-              aria-hidden="true"
-            />
-          )}
-        </label>
-      </div>
+        )}
+      </label>
 
-      {/* Reset button (only shown when an override is active) */}
+      {/* Inline reset button (only shown when an override is active) */}
       {accent !== null && (
-        <div>
-          <Button variant="dp-outline" size="dp-sm" onClick={() => setAccent(null)}>
+        <>
+          {/* Tiny vertical divider so the reset button reads as a separate action */}
+          <span
+            aria-hidden="true"
+            className="mx-1 inline-block h-5 w-px bg-[color:var(--dp-border)]"
+          />
+          <Button variant="dp-ghost" size="dp-sm" onClick={() => setAccent(null)}>
             {t("settings.row.accent.reset")}
           </Button>
-        </div>
+        </>
       )}
     </div>
   );

--- a/src/renderer/features/settings/SettingRow.tsx
+++ b/src/renderer/features/settings/SettingRow.tsx
@@ -10,6 +10,12 @@ export type SettingRowProps = {
   disabled?: boolean;
   /** Adds a top border to visually separate from the previous row. */
   divided?: boolean;
+  /**
+   * When true, stacks label/description above the control (full-width below)
+   * instead of using the 2-col grid. Use for controls that don't fit cleanly
+   * in the 240px right column (e.g. swatch pickers, JSON textareas).
+   */
+  stacked?: boolean;
   className?: string;
 };
 
@@ -19,8 +25,34 @@ export function SettingRow({
   control,
   disabled,
   divided,
+  stacked,
   className,
 }: SettingRowProps) {
+  if (stacked) {
+    return (
+      <div
+        className={cn(
+          "flex flex-col gap-3 py-4",
+          divided && "border-t border-[color:var(--dp-border-soft)]",
+          disabled && "opacity-50 pointer-events-none",
+          className,
+        )}
+      >
+        <div className="min-w-0">
+          <div className="text-[13px] font-medium text-[color:var(--dp-text)] leading-tight">
+            {label}
+          </div>
+          {description != null && (
+            <div className="mt-1 font-mono text-[10px] leading-relaxed text-[color:var(--dp-text-dimmer)]">
+              {description}
+            </div>
+          )}
+        </div>
+        <div>{control}</div>
+      </div>
+    );
+  }
+
   return (
     <div
       className={cn(

--- a/src/renderer/features/settings/sections/AppearanceSection.tsx
+++ b/src/renderer/features/settings/sections/AppearanceSection.tsx
@@ -46,6 +46,7 @@ export function AppearanceSection(props: AppearanceSectionProps) {
       <div className="mt-6">
         <SectionLabel>{t("settings.subsection.accent")}</SectionLabel>
         <SettingRow
+          stacked
           label={t("settings.row.accent.label")}
           description={t("settings.row.accent.description")}
           control={<AccentPicker accent={props.accent} setAccent={props.setAccent} />}


### PR DESCRIPTION
## Summary

The Accent Color row in Settings → Appearance felt unbalanced — the picker (8 swatches + custom + reset) didn't fit the 240px right column, wrapped to 2 internal rows, and left a big void of empty space next to the short description on the left.

**Stacked on:** PR #38 (Phase 17 font picker).

## What changed

### `SettingRow.tsx` — new `stacked` variant

Adds an optional `stacked?: boolean` prop. When true:
- Label + description sit on top spanning full panel width
- Control gets the full remaining width below

Default (unstacked) behavior is unchanged — the existing 2-col grid stays for Toggles, Selects, narrow inputs.

### `AccentPicker.tsx` — single-row layout

- Swatches, custom color, and (conditional) reset button now sit in ONE `flex-wrap` row instead of being stacked internally
- Swatches: 32px → 28px (`h-7 w-7`) for density without losing tap target
- Reset becomes a `dp-ghost` button preceded by a thin vertical divider so it reads as a separate action without dominating
- Check icon overlay sized down to 12px to match smaller swatches

### `AppearanceSection.tsx`

The accent SettingRow now uses `stacked` so it spans full panel width.

## Verification

- Tests: 214/214 passing
- Lint: 0 errors, 4 pre-existing warnings unchanged
- Build: clean

## Visual outcome

Before:
```
[ Accent color           ] [ 🟣🔵🟢🟡🟠       ]
[ Description...          ] [ 🌈                ]
[                          ] [ [ Reset to default ] ]
[ (big empty void here)  ]
```

After:
```
[ Accent color                                              ]
[ Description spans full width...                            ]
[ 🟣🔵🟢🟡🟠🟢🌹⚪🌈 │ Reset to default                       ]
```

## Test plan

- [ ] Open Settings → Appearance → see accent picker spread across full panel width (no wrap on default panel size)
- [ ] Pick any preset → reset button appears inline after divider
- [ ] Resize window very narrow → swatches + reset wrap gracefully via flex-wrap
- [ ] No regression on other SettingRows (Engine section "Launch at login", Alerts toggles, etc. still use the 2-col grid)
- [ ] Font pair row (Phase 17 addition just above) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)