### PR TITLE
Fix — Queue filters to target game (no more random cross-game mix)

### DIFF
--- a/src/renderer/features/overview/OverviewView.tsx
+++ b/src/renderer/features/overview/OverviewView.tsx
@@ -110,7 +110,11 @@ export function OverviewView({
           onClaimNow={onClaimNow}
           claimStatus={claimStatus}
         />
-        <QueuePanel items={items} activeDrop={activeDrop ?? null} />
+        <QueuePanel
+          items={items}
+          activeDrop={activeDrop ?? null}
+          targetGame={activeGame}
+        />
       </div>
       <div className="flex flex-col gap-4">
         <ActivityPanel />

--- a/src/renderer/features/overview/QueuePanel.tsx
+++ b/src/renderer/features/overview/QueuePanel.tsx
@@ -24,20 +24,56 @@ export type QueuePanelProps = {
    * accent border-l so the user can see live progress in the queue list.
    */
   activeDrop?: { id: string; earnedMinutes: number } | null;
+  /**
+   * The current target game. When set, the queue filters to only this game's
+   * drops so the list answers "what's next for what I'm farming" instead of
+   * showing an arbitrary cross-game mix sorted by remaining time.
+   */
+  targetGame?: string;
 };
 
-export function QueuePanel({ items, onManageClick, maxRows = 8, activeDrop }: QueuePanelProps) {
+export function QueuePanel({
+  items,
+  onManageClick,
+  maxRows = 8,
+  activeDrop,
+  targetGame,
+}: QueuePanelProps) {
   const { t } = useI18n();
+  const hasTarget = !!targetGame && targetGame.length > 0;
   const queued = React.useMemo(() => {
-    return items
-      .filter((it) => it.status !== "claimed")
+    const filtered = items.filter((it) => {
+      if (it.status === "claimed") return false;
+      if (hasTarget && it.game !== targetGame) return false;
+      return true;
+    });
+    return filtered
       .sort((a, b) => {
+        // Active drop pinned to the top — it's what the user is actually watching
+        if (activeDrop) {
+          if (a.id === activeDrop.id) return -1;
+          if (b.id === activeDrop.id) return 1;
+        }
+        // Then in-progress (any earnedMinutes > 0) before truly fresh ones —
+        // these are the next-most-likely things to finish.
+        const aProgress = a.earnedMinutes > 0 ? 1 : 0;
+        const bProgress = b.earnedMinutes > 0 ? 1 : 0;
+        if (aProgress !== bProgress) return bProgress - aProgress;
+        // Finally sort by remaining minutes ascending — quickest finish first.
         const remA = Math.max(0, a.requiredMinutes - a.earnedMinutes);
         const remB = Math.max(0, b.requiredMinutes - b.earnedMinutes);
         return remA - remB;
       })
       .slice(0, maxRows);
-  }, [items, maxRows]);
+  }, [items, maxRows, activeDrop, targetGame, hasTarget]);
+
+  // Count what's available outside the target so the user can see "X more in
+  // other games" — explains why the queue looks short when targetGame filters
+  // most things out.
+  const otherGamesCount = React.useMemo(() => {
+    if (!hasTarget) return 0;
+    return items.filter((it) => it.status !== "claimed" && it.game !== targetGame).length;
+  }, [items, hasTarget, targetGame]);
 
   return (
     <Card className="bg-[color:var(--dp-bg-elevated)] border-[color:var(--dp-border)] rounded-[var(--dp-radius-lg)]">
@@ -50,7 +86,14 @@ export function QueuePanel({ items, onManageClick, maxRows = 8, activeDrop }: Qu
       <CardContent className="p-0">
         {queued.length === 0 ? (
           <div className="px-5 py-8 text-center font-mono text-[11px] text-[color:var(--dp-text-dimmer)]">
-            {t("queue.empty")}
+            {hasTarget
+              ? t("queue.emptyForTarget", { game: targetGame! })
+              : t("queue.emptyNoTarget")}
+            {hasTarget && otherGamesCount > 0 && (
+              <div className="mt-1 text-[color:var(--dp-text-dimmer)]">
+                {t("queue.otherGamesHint", { count: otherGamesCount })}
+              </div>
+            )}
           </div>
         ) : (
           <Table columns="40px 2fr 1fr 1fr 110px">
@@ -115,6 +158,14 @@ export function QueuePanel({ items, onManageClick, maxRows = 8, activeDrop }: Qu
               );
             })}
           </Table>
+        )}
+        {/* Footer hint when filtered AND we hid drops from other games.
+            Helps the user understand they're seeing a focused slice, not
+            an exhaustive list. */}
+        {queued.length > 0 && hasTarget && otherGamesCount > 0 && (
+          <div className="border-t border-[color:var(--dp-border-soft)] px-5 py-2 font-mono text-[10px] text-[color:var(--dp-text-dimmer)] text-center">
+            {t("queue.otherGamesHint", { count: otherGamesCount })}
+          </div>
         )}
       </CardContent>
     </Card>

--- a/src/renderer/shared/i18n.tsx
+++ b/src/renderer/shared/i18n.tsx
@@ -833,6 +833,9 @@ const translations: Translations = {
     "queue.pill.live": "live",
     "queue.pill.queued": "queued",
     "queue.pill.watching": "watching",
+    "queue.emptyForTarget": "No queued drops for {game} — pick the next target in Priorities",
+    "queue.emptyNoTarget": "No target game set — pick one in Priorities to see its queue",
+    "queue.otherGamesHint": "+{count} more in other games (see Inventory)",
 
     // activity.* — Overview activity feed (Phase 18)
     "activity.header": "recent activity",
@@ -1788,6 +1791,9 @@ const translations: Translations = {
     "queue.pill.live": "live",
     "queue.pill.queued": "queue",
     "queue.pill.watching": "läuft",
+    "queue.emptyForTarget": "Keine Drops in der Queue für {game} — wähle das nächste Ziel in Prioritäten",
+    "queue.emptyNoTarget": "Kein Ziel-Spiel gesetzt — wähle eins in Prioritäten um seine Queue zu sehen",
+    "queue.otherGamesHint": "+{count} weitere in anderen Spielen (siehe Inventar)",
 
     // activity.* — Overview activity feed (Phase 18)
     "activity.header": "letzte aktivität",


### PR DESCRIPTION
## Summary

The Overview Queue was showing drops from ANY game in the inventory, sorted by remaining minutes. So while watching Marvel Rivals you'd see a random Subnautica 2 drop queued just because it had less remaining time. The user (rightly) called this nonsensical.

**Stacked on:** PR #40 (Phase 18 activity feed).

## What changed

### QueuePanel — target-aware filter

When the `targetGame` prop is set (default: `activeGame` from useAppModel = the user's current farming target):

- **Filters** to only `item.game === targetGame` non-claimed drops
- **Sort** order (3 tiers):
  1. Active drop pinned to top (the one being watched)
  2. Drops with progress (`earnedMinutes > 0`) — most likely to finish next
  3. Fresh drops (`earnedMinutes === 0`)
  Within each tier: remaining minutes ascending

### Smart empty states

| Condition | Message |
|---|---|
| Target set, no matches | "No queued drops for {game} — pick the next target in Priorities" |
| No target set at all | "No target game set — pick one in Priorities to see its queue" |

### Cross-game hint

If there are drops for OTHER games hidden by the filter, the user gets a "+N more in other games (see Inventory)" hint:
- In the empty state: appears below the message
- In a populated list: thin footer below the table

So the user always knows the Inventory view has the full picture.

### Graceful degradation

When `targetGame` is empty/undefined (no target picked), behavior falls back to the old "sort all non-claimed by remaining" with the no-target empty state hint — nothing breaks, just less focused.

## Files

- `src/renderer/features/overview/QueuePanel.tsx` — new `targetGame?` prop, filter + sort + empty/footer logic
- `src/renderer/features/overview/OverviewView.tsx` — passes `activeGame` as `targetGame`
- `src/renderer/shared/i18n.tsx` — 3 new EN+DE keys

## Verification

- Tests: 214/214 passing
- Lint: 0 errors, 4 pre-existing warnings unchanged
- Build: clean

## Test plan

- [ ] Open Overview while watching Marvel Rivals → Queue shows ONLY Marvel Rivals drops, no other games
- [ ] Footer shows "+N more in other games (see Inventory)" with accurate count
- [ ] If Marvel Rivals has no other unclaimed drops → empty state explains it, with cross-game count below
- [ ] Pick no target game → empty state hints "set one in Priorities"
- [ ] Active drop is always at top of the queue (pinned)
- [ ] Switch language → all new strings translate
- [ ] Open Inventory view → full picture still works (no filter applied there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)