### PR TITLE
Fix — PubSub instrumentation + startup race (drop-progress events not arriving)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -532,6 +532,21 @@ app.whenReady().then(async () => {
     applyAutoStartSetting,
   });
 
+  // Pipe userPubSub diagnostic logs to ALL renderer windows via the existing
+  // 'main-log' channel — they show up in the DebugView's Log panel. Without
+  // this, [userPubSub] lines only land in the main process stdout, which is
+  // invisible in packaged builds (and only available in the dev terminal).
+  userPubSub.setLogger((level, message, data) => {
+    const scope = level === "warn" ? "userPubSub:warn" : "userPubSub";
+    const args = data !== undefined ? [message, data] : [message];
+    if (level === "warn") console.warn(`[${scope}]`, ...args);
+    else console.log(`[${scope}]`, ...args);
+    for (const w of BrowserWindow.getAllWindows()) {
+      if (w.isDestroyed()) continue;
+      w.webContents.send("main-log", { scope, args });
+    }
+  });
+
   // Start the user PubSub connection AFTER the IPC handlers register the
   // userPubSub.onEvent listener that forwards events to renderer windows.
   // Otherwise early RESPONSE / MESSAGE frames are received before any

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -482,7 +482,12 @@ app.whenReady().then(async () => {
   }
   createTray(win);
   setupAutoUpdater();
-  userPubSub.start();
+  // NOTE: deliberately NOT calling userPubSub.start() here. It used to run
+  // BEFORE registerIpcHandlers() below, which meant the IPC bridge listener
+  // (registered inside registerIpcHandlers via userPubSub.onEvent) wasn't
+  // attached when the first connection's RESPONSE / early MESSAGE frames
+  // arrived — events silently dropped. start() now runs at the end of this
+  // block, after the IPC handlers are registered.
   if (initialSettings) {
     applyAutoStartSetting(initialSettings.autoStart);
   }
@@ -526,6 +531,14 @@ app.whenReady().then(async () => {
     resetStats,
     applyAutoStartSetting,
   });
+
+  // Start the user PubSub connection AFTER the IPC handlers register the
+  // userPubSub.onEvent listener that forwards events to renderer windows.
+  // Otherwise early RESPONSE / MESSAGE frames are received before any
+  // listener exists in the Set and get silently dropped — which manifested
+  // as 'no drop progress ever arrives' even on a successful connection.
+  console.log("[main] starting userPubSub (IPC handlers now registered)");
+  userPubSub.start();
 
   app.on("activate", () => {
     if (BrowserWindow.getAllWindows().length === 0) {

--- a/src/main/twitch/userPubSub.ts
+++ b/src/main/twitch/userPubSub.ts
@@ -1,14 +1,6 @@
 import type { SessionData } from "../core/storage";
 import { WebSocket as NodeWebSocket, type RawData } from "ws";
 
-// Scoped logger so every line is grep-friendly in the console / DebugView.
-// Until this fix landed, UserPubSub had ZERO logging — every failure mode
-// (auth expired, validate 401, ws error, listen rejected, malformed payload)
-// was completely silent, which made debugging "no drop progress arrives"
-// impossible without instrumented builds. Keep this verbose.
-const log = (...args: unknown[]) => console.log("[userPubSub]", ...args);
-const logWarn = (...args: unknown[]) => console.warn("[userPubSub]", ...args);
-
 const PUBSUB_URL = "wss://pubsub-edge.twitch.tv/v1";
 const DROPS_TOPIC_PREFIX = "user-drop-events.";
 const NOTIFICATIONS_TOPIC_PREFIX = "onsite-notifications.";
@@ -68,6 +60,14 @@ type UserPubSubOptions = {
   pingIntervalMs?: number;
   authSyncIntervalMs?: number;
   notificationTypes?: Set<string>;
+  /**
+   * Optional log sink. When set, every diagnostic line goes here in addition
+   * to console. Main process wires this to forward to renderer windows via
+   * 'main-log' IPC so logs appear in the DebugView's log panel (where users
+   * can actually see them — main process stdout is invisible in packaged
+   * builds and only available in the dev terminal otherwise).
+   */
+  onLog?: (level: "log" | "warn", message: string, data?: unknown) => void;
 };
 
 const toMessageText = (raw: unknown): string => {
@@ -211,6 +211,7 @@ export class UserPubSub {
   private readonly pingIntervalMs: number;
   private readonly authSyncIntervalMs: number;
   private readonly notificationTypes: Set<string>;
+  private onLog?: UserPubSubOptions["onLog"];
 
   constructor(
     private readonly sessionProvider: () => Promise<SessionData | null>,
@@ -222,6 +223,25 @@ export class UserPubSub {
     this.pingIntervalMs = Math.max(30_000, opts.pingIntervalMs ?? 4 * 60_000);
     this.authSyncIntervalMs = Math.max(5_000, opts.authSyncIntervalMs ?? 20_000);
     this.notificationTypes = opts.notificationTypes ?? DEFAULT_NOTIFICATION_TYPES;
+    this.onLog = opts.onLog;
+  }
+
+  /**
+   * Internal log helpers — emit to both console (main stdout) AND the optional
+   * onLog sink (typically wired to forward to renderer windows so logs show
+   * up in the DebugView, which is the only place users can see them in
+   * packaged builds).
+   */
+  private log(message: string, data?: unknown) {
+    if (data !== undefined) console.log("[userPubSub]", message, data);
+    else console.log("[userPubSub]", message);
+    this.onLog?.("log", message, data);
+  }
+
+  private logWarn(message: string, data?: unknown) {
+    if (data !== undefined) console.warn("[userPubSub]", message, data);
+    else console.warn("[userPubSub]", message);
+    this.onLog?.("warn", message, data);
   }
 
   start() {
@@ -267,6 +287,15 @@ export class UserPubSub {
       events: this.events,
       currentUserId: this.currentUserId ?? undefined,
     };
+  }
+
+  /**
+   * Late-bind the log sink — useful when the consumer (e.g. main process)
+   * needs to set up the sink AFTER UserPubSub is constructed (because the
+   * sink depends on a BrowserWindow that doesn't exist until app.whenReady).
+   */
+  setLogger(onLog: UserPubSubOptions["onLog"] | undefined) {
+    this.onLog = onLog;
   }
 
   onEvent(listener: UserPubSubListener): () => void {
@@ -372,20 +401,20 @@ export class UserPubSub {
     if (!this.running || this.disposed) return;
     if (this.ws && this.connectionState !== "disconnected") return;
     this.connectionState = "connecting";
-    log("ensureConnection: resolving auth context");
+    this.log("ensureConnection: resolving auth context");
     const auth = await this.resolveAuthContext();
     if (!auth) {
       this.connectionState = "disconnected";
       this.listening = false;
       this.state = this.state === "error" ? "error" : "idle";
-      logWarn(
+      this.logWarn(
         "ensureConnection: auth context unavailable — pubsub stays disconnected (reschedule)",
         { lastErrorMessage: this.lastErrorMessage },
       );
       this.scheduleReconnect(this.authSyncIntervalMs);
       return;
     }
-    log("ensureConnection: auth ok, opening websocket", { userId: auth.userId });
+    this.log("ensureConnection: auth ok, opening websocket", { userId: auth.userId });
 
     this.currentAccessToken = auth.accessToken;
     this.currentUserId = auth.userId;
@@ -393,7 +422,7 @@ export class UserPubSub {
     try {
       ws = new NodeWebSocket(this.wsUrl);
     } catch (err) {
-      logWarn("ensureConnection: ws constructor threw", err);
+      this.logWarn("ensureConnection: ws constructor threw", err);
       this.markError(err);
       this.scheduleReconnect();
       return;
@@ -408,7 +437,7 @@ export class UserPubSub {
       this.reconnectAttempts = 0;
       this.lastErrorMessage = undefined;
       this.startPingLoop();
-      log("ws open — sending LISTEN", {
+      this.log("ws open — sending LISTEN", {
         topics: [
           `${DROPS_TOPIC_PREFIX}${auth.userId}`,
           `${NOTIFICATIONS_TOPIC_PREFIX}${auth.userId}`,
@@ -422,13 +451,13 @@ export class UserPubSub {
     });
     ws.on("error", (err) => {
       if (this.ws !== ws) return;
-      logWarn("ws error", err);
+      this.logWarn("ws error", err);
       this.markError(err);
     });
     ws.on("close", (code, reason) => {
       if (this.ws !== ws) return;
       const reasonText = reason instanceof Buffer ? reason.toString("utf-8") : String(reason);
-      log("ws close — scheduling reconnect", { code, reason: reasonText });
+      this.log("ws close — scheduling reconnect", { code, reason: reasonText });
       this.ws = null;
       this.listening = false;
       this.connectionState = "disconnected";
@@ -542,12 +571,12 @@ export class UserPubSub {
       const error = String(envelope.error ?? "").trim();
       if (error.length > 0) {
         this.listening = false;
-        logWarn("LISTEN rejected by Twitch", { error });
+        this.logWarn("LISTEN rejected by Twitch", { error });
         this.markError(`PubSub listen failed: ${error}`);
         this.disconnect("PubSub listen failed", false);
         this.scheduleReconnect(this.reconnectMinMs);
       } else {
-        log("LISTEN accepted — now receiving drop-progress / drop-claim events");
+        this.log("LISTEN accepted — now receiving drop-progress / drop-claim events");
         this.listening = true;
         this.state = "ok";
         this.lastErrorMessage = undefined;
@@ -566,13 +595,13 @@ export class UserPubSub {
       // Unrecognized inner payload — could be a new event type Twitch added.
       // Log the raw topic + message preview so we can spot it without a debugger.
       const preview = (envelope.data?.message ?? "").slice(0, 200);
-      log("MESSAGE ignored (unrecognized payload kind)", {
+      this.log("MESSAGE ignored (unrecognized payload kind)", {
         topic: envelope.data?.topic,
         preview,
       });
       return;
     }
-    log("event received → forwarding to listeners", {
+    this.log("event received → forwarding to listeners", {
       kind: event.kind,
       dropId: event.dropId,
       messageType: event.messageType,
@@ -586,7 +615,7 @@ export class UserPubSub {
       try {
         listener(event);
       } catch (err) {
-        logWarn("listener threw", err);
+        this.logWarn("listener threw", err);
       }
     }
   }
@@ -600,12 +629,12 @@ export class UserPubSub {
 
   private async resolveAuthContext(): Promise<AuthContext | null> {
     const session = await this.sessionProvider().catch((err) => {
-      logWarn("sessionProvider threw", err);
+      this.logWarn("sessionProvider threw", err);
       return null;
     });
     const accessToken = session?.accessToken?.trim();
     if (!accessToken) {
-      logWarn("no access token in session — user not logged in?");
+      this.logWarn("no access token in session — user not logged in?");
       return null;
     }
     let res: Response;
@@ -616,7 +645,7 @@ export class UserPubSub {
         },
       });
     } catch (err) {
-      logWarn("validate fetch threw — network down?", err);
+      this.logWarn("validate fetch threw — network down?", err);
       this.markError(err);
       return null;
     }
@@ -624,12 +653,12 @@ export class UserPubSub {
       // This is the most common silent-kill cause: stored token has expired
       // or been revoked. The auth controller should refresh it; meanwhile we
       // stay disconnected and retry.
-      logWarn("validate returned 401 — access token expired/revoked, pubsub will retry");
+      this.logWarn("validate returned 401 — access token expired/revoked, pubsub will retry");
       this.markError("Access token expired (401 from validate)");
       return null;
     }
     if (!res.ok) {
-      logWarn("validate returned non-ok", { status: res.status });
+      this.logWarn("validate returned non-ok", { status: res.status });
       this.markError(`Validate failed (${res.status})`);
       return null;
     }
@@ -637,13 +666,13 @@ export class UserPubSub {
     try {
       data = (await res.json()) as { user_id?: string };
     } catch (err) {
-      logWarn("validate response not JSON", err);
+      this.logWarn("validate response not JSON", err);
       this.markError(err);
       return null;
     }
     const userId = data.user_id?.trim();
     if (!userId) {
-      logWarn("validate response missing user_id");
+      this.logWarn("validate response missing user_id");
       return null;
     }
     return { accessToken, userId };

--- a/src/main/twitch/userPubSub.ts
+++ b/src/main/twitch/userPubSub.ts
@@ -1,6 +1,14 @@
 import type { SessionData } from "../core/storage";
 import { WebSocket as NodeWebSocket, type RawData } from "ws";
 
+// Scoped logger so every line is grep-friendly in the console / DebugView.
+// Until this fix landed, UserPubSub had ZERO logging — every failure mode
+// (auth expired, validate 401, ws error, listen rejected, malformed payload)
+// was completely silent, which made debugging "no drop progress arrives"
+// impossible without instrumented builds. Keep this verbose.
+const log = (...args: unknown[]) => console.log("[userPubSub]", ...args);
+const logWarn = (...args: unknown[]) => console.warn("[userPubSub]", ...args);
+
 const PUBSUB_URL = "wss://pubsub-edge.twitch.tv/v1";
 const DROPS_TOPIC_PREFIX = "user-drop-events.";
 const NOTIFICATIONS_TOPIC_PREFIX = "onsite-notifications.";
@@ -364,14 +372,20 @@ export class UserPubSub {
     if (!this.running || this.disposed) return;
     if (this.ws && this.connectionState !== "disconnected") return;
     this.connectionState = "connecting";
+    log("ensureConnection: resolving auth context");
     const auth = await this.resolveAuthContext();
     if (!auth) {
       this.connectionState = "disconnected";
       this.listening = false;
       this.state = this.state === "error" ? "error" : "idle";
+      logWarn(
+        "ensureConnection: auth context unavailable — pubsub stays disconnected (reschedule)",
+        { lastErrorMessage: this.lastErrorMessage },
+      );
       this.scheduleReconnect(this.authSyncIntervalMs);
       return;
     }
+    log("ensureConnection: auth ok, opening websocket", { userId: auth.userId });
 
     this.currentAccessToken = auth.accessToken;
     this.currentUserId = auth.userId;
@@ -379,6 +393,7 @@ export class UserPubSub {
     try {
       ws = new NodeWebSocket(this.wsUrl);
     } catch (err) {
+      logWarn("ensureConnection: ws constructor threw", err);
       this.markError(err);
       this.scheduleReconnect();
       return;
@@ -393,6 +408,12 @@ export class UserPubSub {
       this.reconnectAttempts = 0;
       this.lastErrorMessage = undefined;
       this.startPingLoop();
+      log("ws open — sending LISTEN", {
+        topics: [
+          `${DROPS_TOPIC_PREFIX}${auth.userId}`,
+          `${NOTIFICATIONS_TOPIC_PREFIX}${auth.userId}`,
+        ],
+      });
       this.sendListen(auth);
     });
     ws.on("message", (raw: RawData) => {
@@ -401,10 +422,13 @@ export class UserPubSub {
     });
     ws.on("error", (err) => {
       if (this.ws !== ws) return;
+      logWarn("ws error", err);
       this.markError(err);
     });
-    ws.on("close", () => {
+    ws.on("close", (code, reason) => {
       if (this.ws !== ws) return;
+      const reasonText = reason instanceof Buffer ? reason.toString("utf-8") : String(reason);
+      log("ws close — scheduling reconnect", { code, reason: reasonText });
       this.ws = null;
       this.listening = false;
       this.connectionState = "disconnected";
@@ -518,10 +542,12 @@ export class UserPubSub {
       const error = String(envelope.error ?? "").trim();
       if (error.length > 0) {
         this.listening = false;
+        logWarn("LISTEN rejected by Twitch", { error });
         this.markError(`PubSub listen failed: ${error}`);
         this.disconnect("PubSub listen failed", false);
         this.scheduleReconnect(this.reconnectMinMs);
       } else {
+        log("LISTEN accepted — now receiving drop-progress / drop-claim events");
         this.listening = true;
         this.state = "ok";
         this.lastErrorMessage = undefined;
@@ -536,7 +562,22 @@ export class UserPubSub {
       Date.now(),
       this.notificationTypes,
     );
-    if (!event) return;
+    if (!event) {
+      // Unrecognized inner payload — could be a new event type Twitch added.
+      // Log the raw topic + message preview so we can spot it without a debugger.
+      const preview = (envelope.data?.message ?? "").slice(0, 200);
+      log("MESSAGE ignored (unrecognized payload kind)", {
+        topic: envelope.data?.topic,
+        preview,
+      });
+      return;
+    }
+    log("event received → forwarding to listeners", {
+      kind: event.kind,
+      dropId: event.dropId,
+      messageType: event.messageType,
+      listenerCount: this.listeners.size,
+    });
     this.state = "ok";
     this.lastErrorMessage = undefined;
     this.lastMessageAt = event.at;
@@ -544,8 +585,8 @@ export class UserPubSub {
     for (const listener of this.listeners) {
       try {
         listener(event);
-      } catch {
-        // ignore listener errors
+      } catch (err) {
+        logWarn("listener threw", err);
       }
     }
   }
@@ -558,9 +599,15 @@ export class UserPubSub {
   }
 
   private async resolveAuthContext(): Promise<AuthContext | null> {
-    const session = await this.sessionProvider().catch(() => null);
+    const session = await this.sessionProvider().catch((err) => {
+      logWarn("sessionProvider threw", err);
+      return null;
+    });
     const accessToken = session?.accessToken?.trim();
-    if (!accessToken) return null;
+    if (!accessToken) {
+      logWarn("no access token in session — user not logged in?");
+      return null;
+    }
     let res: Response;
     try {
       res = await fetch("https://id.twitch.tv/oauth2/validate", {
@@ -569,13 +616,20 @@ export class UserPubSub {
         },
       });
     } catch (err) {
+      logWarn("validate fetch threw — network down?", err);
       this.markError(err);
       return null;
     }
     if (res.status === 401) {
+      // This is the most common silent-kill cause: stored token has expired
+      // or been revoked. The auth controller should refresh it; meanwhile we
+      // stay disconnected and retry.
+      logWarn("validate returned 401 — access token expired/revoked, pubsub will retry");
+      this.markError("Access token expired (401 from validate)");
       return null;
     }
     if (!res.ok) {
+      logWarn("validate returned non-ok", { status: res.status });
       this.markError(`Validate failed (${res.status})`);
       return null;
     }
@@ -583,11 +637,15 @@ export class UserPubSub {
     try {
       data = (await res.json()) as { user_id?: string };
     } catch (err) {
+      logWarn("validate response not JSON", err);
       this.markError(err);
       return null;
     }
     const userId = data.user_id?.trim();
-    if (!userId) return null;
+    if (!userId) {
+      logWarn("validate response missing user_id");
+      return null;
+    }
     return { accessToken, userId };
   }
 }

--- a/src/renderer/shared/hooks/inventory/useInventory.ts
+++ b/src/renderer/shared/hooks/inventory/useInventory.ts
@@ -328,9 +328,21 @@ export function useInventory(isLinked: boolean, events?: InventoryEvents, opts?:
   }, [demoMode]);
 
   useEffect(() => {
-    if (demoMode || !isLinked) return;
+    if (demoMode || !isLinked) {
+      // Silent kill #1: if the account isn't linked yet, the renderer never
+      // subscribes to drop-progress events, and earnedMinutes never advances
+      // mid-session. Log it so DevView shows why we're not seeing live data.
+      logDebug("inventory: pubsub subscription skipped", { demoMode, isLinked });
+      return;
+    }
     const pubSubReconciler = pubSubReconcilerRef.current;
-    if (!pubSubReconciler) return;
+    if (!pubSubReconciler) {
+      // Silent kill #2: reconciler ref not yet initialized. This is normally
+      // a brief startup window, but if it persists, no events are applied.
+      logDebug("inventory: pubsub reconciler not ready");
+      return;
+    }
+    logDebug("inventory: pubsub subscription attached");
 
     const applyPatch = (
       event: UserPubSubEvent,


### PR DESCRIPTION
## Summary

User reports PubSub `drop-progress` events never arrive — ETA stays static, earnedMinutes never advances mid-session even after the game-name normalization fix (PR #42). Investigation revealed THREE silent-kill failure modes in the PubSub chain, none of which had any logging.

**Stacked on:** PR #42 (game-name normalization).

## Three problems found

### 1. Zero logging in `UserPubSub` (main process)

Until this fix, `src/main/twitch/userPubSub.ts` had **zero** `console.log` or `console.warn` calls. Every failure path — expired token, validate 401, WS error, LISTEN rejected, unrecognized payload kind, listener crash — was silent. Diagnosing "no drop progress" was impossible without an instrumented build.

### 2. Startup race condition

`main/index.ts` called `userPubSub.start()` **before** `registerIpcHandlers()`. The IPC bridge listener (which forwards `userPubSub.onEvent` to renderer windows via `webContents.send`) is registered inside `registerIpcHandlers`. So during the window between start and registration, the WebSocket could open, send LISTEN, get a RESPONSE, and even receive early MESSAGE frames — all of which iterated an EMPTY listener Set and silently dropped.

### 3. Silent kill in renderer subscription

`src/renderer/shared/hooks/inventory/useInventory.ts` line 331 has `if (demoMode || !isLinked) return;`. If the user's account is not linked (transient auth state, or scope issue), the renderer never attaches the `onUserPubSubEvent` handler — events reach IPC but are discarded. No log, no signal.

## Fixes

### `src/main/twitch/userPubSub.ts`

Comprehensive `[userPubSub]`-prefixed logging at every state transition:

- `ensureConnection` entry / auth result
- `ws open` + LISTEN topics sent
- `ws error` / `ws close` (with code + reason)
- LISTEN accepted vs rejected (with the Twitch error string)
- `MESSAGE` ignored when payload kind isn't recognized (with topic + 200-char preview so a new Twitch event type is immediately visible)
- Every parsed event with `kind / dropId / messageType / listenerCount` so you can spot listenerCount=0 instantly
- `sessionProvider` throws
- `validate` returns 401 — THE most common silent kill (stale/revoked token)
- `validate` non-ok / non-JSON / missing user_id
- Listener crashes (previously caught and swallowed)

### `src/main/index.ts`

Moved `userPubSub.start()` from line 485 (before `registerIpcHandlers`) to AFTER the IPC handlers register their listener. Added a `[main] starting userPubSub (IPC handlers now registered)` log line so the ordering is observable. Comment explaining the race constraint.

### `src/renderer/shared/hooks/inventory/useInventory.ts`

Added diagnostic `logDebug` calls at the renderer-side silent kills:
- `inventory: pubsub subscription skipped` when `demoMode || !isLinked`
- `inventory: pubsub reconciler not ready` when `pubSubReconcilerRef.current` is null
- `inventory: pubsub subscription attached` on success

These show up in the Debug view (live logs panel) so the user can verify the subscription is alive.

## How to diagnose now

Open DevTools console (Ctrl+Shift+I) and filter `[userPubSub]`:

```
[userPubSub] ensureConnection: resolving auth context
[userPubSub] ensureConnection: auth ok, opening websocket { userId: '...' }
[userPubSub] ws open — sending LISTEN { topics: ['user-drop-events.<id>', 'onsite-notifications.<id>'] }
[userPubSub] LISTEN accepted — now receiving drop-progress / drop-claim events
[userPubSub] event received → forwarding to listeners { kind: 'drop-progress', dropId, messageType, listenerCount: 1 }
```

Symptom decision tree:
- **No `ensureConnection` log** → start() never called → check race ordering
- **`auth context unavailable`** → access token missing → log in
- **`validate returned 401`** → token expired/revoked → log in again
- **`LISTEN rejected by Twitch`** → OAuth scope problem
- **`event received` with `listenerCount: 0`** → IPC bridge listener not registered → check race ordering (this fix should prevent it)
- **Events forwarded but ETA still static** → renderer side: check `inventory: pubsub subscription skipped` log in Debug view

## Verification

- Tests: 214/214 passing
- Lint: 0 errors, 4 pre-existing warnings unchanged
- Build: clean

## Test plan

- [ ] Restart the app, watch the console — `[userPubSub]` lines appear in order
- [ ] If you see `LISTEN accepted` → start a watch session → after a minute, expect `event received → forwarding to listeners { kind: 'drop-progress', ... }` lines
- [ ] If events ARE arriving but ETA still static → that's a separate renderer issue (we have logs now to localize)
- [ ] If `validate returned 401` → log out + back in
- [ ] Check Debug view's Log panel: `inventory: pubsub subscription attached` should appear once the user is linked

## Out of scope (next phase if needed)

- **Surface PubSub disconnect to the user** — currently only visible in DevTools / Debug view. A warn pill in AttentionStrip when watching while pubsub is `disconnected`/`error` would let the user see it without opening dev tools.
- **Auto-refresh expired tokens** — if validate returns 401, we currently retry forever. The auth controller should refresh the access token on this signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)