### PR TITLE
Fix — Live drop progress via DropCurrentSessionContext (channelID was missing)

### DIFF
--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -311,6 +311,21 @@ export function registerIpcHandlers(deps: {
     },
   );
 
+  ipcMain.handle("twitch/dropProgress", async () => {
+    try {
+      const progress = await twitch.fetchDropProgress();
+      return { ok: true, progress };
+    } catch (err) {
+      if (twitch.isAuthError(err)) {
+        return { error: "auth", message: (err as Error).message, status: (err as any).status };
+      }
+      if (err instanceof TwitchServiceError) {
+        return { error: "twitch", code: err.code, message: err.message };
+      }
+      return { error: "unknown", message: err instanceof Error ? err.message : String(err) };
+    }
+  });
+
   ipcMain.handle(
     "twitch/claimDrop",
     async (_e, payload: { dropInstanceId?: string; dropId?: string; campaignId?: string }) => {

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -311,9 +311,9 @@ export function registerIpcHandlers(deps: {
     },
   );
 
-  ipcMain.handle("twitch/dropProgress", async () => {
+  ipcMain.handle("twitch/dropProgress", async (_e, payload: { channelId?: string }) => {
     try {
-      const progress = await twitch.fetchDropProgress();
+      const progress = await twitch.fetchDropProgress(payload?.channelId ?? "");
       return { ok: true, progress };
     } catch (err) {
       if (twitch.isAuthError(err)) {

--- a/src/main/twitch/service.ts
+++ b/src/main/twitch/service.ts
@@ -498,20 +498,32 @@ export class TwitchService {
    * unexpected, or the call fails (logged but non-fatal — caller just keeps
    * the last known progress).
    */
-  async fetchDropProgress(): Promise<{
+  async fetchDropProgress(channelId: string): Promise<{
     dropId: string;
     currentMinutesWatched: number;
     requiredMinutesWatched: number;
     channelId?: string;
     gameName?: string;
   } | null> {
+    const watchedChannelId = String(channelId ?? "").trim();
+    if (!watchedChannelId) {
+      // The DropCurrentSessionContext resolver keys off the watched channel.
+      // Without channelID it ALWAYS returns dropCurrentSession: null, so don't
+      // even spend the request — just keep the last known progress.
+      this.debug("dropProgress: no channelId provided, skipping");
+      return null;
+    }
     const body = createPersistedQuery(
       "DropCurrentSessionContext",
       // Known persisted-query hash used by the Twitch web client + drop miners.
       // If Twitch rotates it, this call returns a PersistedQueryNotFound error
       // (logged below) and we fall back to keeping the last known progress.
       "4d06b702d25d652afb9ef835d2a550031f1cf762b193523a92166f40ea3d142b",
-      {},
+      // channelID (the watched channel id, as a string) is REQUIRED — the
+      // resolver returns dropCurrentSession: null without it. channelLogin is
+      // always "" (mirrors the Twitch web client + TwitchDropsMiner). This was
+      // the bug: we previously sent {} and so always got a null session.
+      { channelID: watchedChannelId, channelLogin: "" },
     );
     let res: DropCurrentSessionResponse;
     try {

--- a/src/main/twitch/service.ts
+++ b/src/main/twitch/service.ts
@@ -385,7 +385,9 @@ export class TwitchService {
     const user = res?.data?.user;
     const stream = user?.stream ?? null;
     if (!stream) return null;
-    const game = stream.game ?? null;
+    // The current game is under broadcastSettings (this is the exact path TDM
+    // reads from the same query/hash); stream.game is a fallback just in case.
+    const game = user?.broadcastSettings?.game ?? stream.game ?? null;
     const gameName = game?.name ?? game?.displayName ?? undefined;
     const gameId = game?.id != null ? String(game.id) : undefined;
     return {

--- a/src/main/twitch/service.ts
+++ b/src/main/twitch/service.ts
@@ -537,13 +537,17 @@ export class TwitchService {
     // is only known empirically.
     this.debug("dropProgress: raw response", res);
     const session = res?.data?.currentUser?.dropCurrentSession ?? null;
-    if (!session) {
-      this.debug("dropProgress: no active session (dropCurrentSession null)");
-      return null;
-    }
-    const dropId = session.dropID?.trim();
-    if (!dropId) {
-      this.debug("dropProgress: session missing dropID", session);
+    const dropId = session?.dropID?.trim();
+    if (!session || !dropId) {
+      // BENIGN: Twitch frequently hands a headless client an empty/absent
+      // dropCurrentSession (dropID: "", channel: null) even while a watch is
+      // active — it does not reliably reflect our spade pings. This is NOT an
+      // error and does NOT mean farming stopped: we return null and the live
+      // estimate + periodic inventory refresh remain the source of truth.
+      this.debug("dropProgress: no live session from Twitch (keeping estimate)", {
+        hasSession: !!session,
+        dropId: dropId ?? "",
+      });
       return null;
     }
     const current = Number(session.currentMinutesWatched);

--- a/src/main/twitch/service.ts
+++ b/src/main/twitch/service.ts
@@ -35,6 +35,7 @@ import {
   type DirectoryPageGameResponse,
   type DirectoryStreamNode,
   type DropCampaignDetailsResponse,
+  type DropCurrentSessionResponse,
   type InventoryResponse,
   type VideoPlayerStreamInfoOverlayChannelResponse,
 } from "./serviceUtils";
@@ -480,6 +481,70 @@ export class TwitchService {
       TWITCH_ERROR_CODES.WATCH_PING_FAILED,
       text ? `Watch ping failed: ${text}` : `Watch ping failed (${res.status})`,
     );
+  }
+
+  /**
+   * Reads the CURRENT drop progress for the channel the user is actively
+   * watching, via the DropCurrentSessionContext GraphQL query. This is the
+   * canonical live-progress source used by drop miners — it reflects the
+   * server-side minutes accrued from the spade `minute-watched` pings.
+   *
+   * Replaces the dead `user-drop-events` PubSub topic (which still accepts a
+   * LISTEN but never delivers drop-progress messages). Twitch returns
+   * `dropCurrentSession: null` when there's no active eligible drop on the
+   * watched channel.
+   *
+   * Returns null when there's no active session, the query shape is
+   * unexpected, or the call fails (logged but non-fatal — caller just keeps
+   * the last known progress).
+   */
+  async fetchDropProgress(): Promise<{
+    dropId: string;
+    currentMinutesWatched: number;
+    requiredMinutesWatched: number;
+    channelId?: string;
+    gameName?: string;
+  } | null> {
+    const body = createPersistedQuery(
+      "DropCurrentSessionContext",
+      // Known persisted-query hash used by the Twitch web client + drop miners.
+      // If Twitch rotates it, this call returns a PersistedQueryNotFound error
+      // (logged below) and we fall back to keeping the last known progress.
+      "4d06b702d25d652afb9ef835d2a550031f1cf762b193523a92166f40ea3d142b",
+      {},
+    );
+    let res: DropCurrentSessionResponse;
+    try {
+      res = await this.gqlRequest<DropCurrentSessionResponse>(body, "DropCurrentSessionContext");
+    } catch (err) {
+      this.debug("dropProgress: gql failed", err);
+      return null;
+    }
+    // Log the raw response so the exact shape can be confirmed at runtime —
+    // critical because this is a newly-wired query and Twitch's contract here
+    // is only known empirically.
+    this.debug("dropProgress: raw response", res);
+    const session = res?.data?.currentUser?.dropCurrentSession ?? null;
+    if (!session) {
+      this.debug("dropProgress: no active session (dropCurrentSession null)");
+      return null;
+    }
+    const dropId = session.dropID?.trim();
+    if (!dropId) {
+      this.debug("dropProgress: session missing dropID", session);
+      return null;
+    }
+    const current = Number(session.currentMinutesWatched);
+    const required = Number(session.requiredMinutesWatched);
+    const result = {
+      dropId,
+      currentMinutesWatched: Number.isFinite(current) ? Math.max(0, current) : 0,
+      requiredMinutesWatched: Number.isFinite(required) ? Math.max(0, required) : 0,
+      channelId: session.channel?.id ? String(session.channel.id) : undefined,
+      gameName: session.game?.name ?? session.game?.displayName ?? undefined,
+    };
+    this.debug("dropProgress: parsed", result);
+    return result;
   }
 
   private async fetchCampaignEdges(opts?: {

--- a/src/main/twitch/service.ts
+++ b/src/main/twitch/service.ts
@@ -1,3 +1,4 @@
+import { gzipSync } from "node:zlib";
 import type { SessionData } from "../core/storage";
 import { TWITCH_WEB_USER_AGENT } from "../config";
 import { TwitchClient, TwitchAuthError, type RevalidateResult, type TwitchUser } from "./client";
@@ -364,6 +365,8 @@ export class TwitchService {
     broadcastId?: string;
     channelId?: string;
     streamId?: string;
+    gameName?: string;
+    gameId?: string;
   } | null> {
     const body = {
       operationName: "VideoPlayerStreamInfoOverlayChannel",
@@ -382,10 +385,15 @@ export class TwitchService {
     const user = res?.data?.user;
     const stream = user?.stream ?? null;
     if (!stream) return null;
+    const game = stream.game ?? null;
+    const gameName = game?.name ?? game?.displayName ?? undefined;
+    const gameId = game?.id != null ? String(game.id) : undefined;
     return {
       broadcastId: stream.id ?? stream.stream?.id,
       channelId: user?.id,
       streamId: stream.id,
+      gameName,
+      gameId,
     };
   }
 
@@ -400,9 +408,7 @@ export class TwitchService {
       throw new TwitchServiceError(TWITCH_ERROR_CODES.WATCH_OFFLINE, "Watch stream offline");
     }
 
-    const spadeUrl = await this.resolveSpadeUrl(login);
     const validate = await this.client.getValidateInfo();
-    const cookieHeader = await this.client.getCookieHeader().catch(() => "");
     const broadcastId = streamInfo.broadcastId ?? payload.streamId ?? streamInfo.streamId;
     const channelId = streamInfo.channelId ?? payload.channelId;
 
@@ -413,73 +419,76 @@ export class TwitchService {
       );
     }
 
-    const payloadBody = [
+    // Twitch no longer credits minute-watched via a plain POST to the spade
+    // beacon URL — that endpoint still answers 204 but the watch is NOT counted
+    // (which is why progress sat frozen and the engine kept false-stalling). The
+    // web client + TwitchDropsMiner now send it as the `SendEvents` GraphQL
+    // mutation (sendSpadeEvents), which rides our authenticated + integrity-
+    // checked GQL channel. The event array is gzipped, then base64-encoded
+    // ("GZIP_B64") — exactly TDM's Stream._gql_payload.
+    const userIdNum = Number(validate.userId);
+    const eventPayload = [
       {
         event: "minute-watched",
         properties: {
           broadcast_id: String(broadcastId),
           channel_id: String(channelId),
           channel: login,
+          client_time: new Date().toISOString(),
+          game: streamInfo.gameName ?? "",
+          game_id: streamInfo.gameId ?? "",
           hidden: false,
+          is_live: true,
           live: true,
-          location: "channel",
           logged_in: true,
+          minutes_logged: 1,
           muted: false,
-          player: "site",
-          user_id: Number(validate.userId),
+          user_id: Number.isFinite(userIdNum) ? userIdNum : validate.userId,
         },
       },
     ];
-
-    const data = Buffer.from(JSON.stringify(payloadBody)).toString("base64");
-    const formBody = new URLSearchParams({ data }).toString();
-
-    this.debug("Watch ping start", {
-      login,
-      channelId,
-      streamId: payload.streamId ?? streamInfo.streamId,
-      broadcastId,
-      spade: spadeUrl ?? "<none>",
-      hasCookieHeader: cookieHeader.length > 0,
-      payloadEventCount: payloadBody.length,
-    });
-
-    // Keep headers minimal.
-    const headers: Record<string, string> = {
-      "Content-Type": "application/x-www-form-urlencoded; charset=utf-8",
-      "User-Agent": TWITCH_WEB_USER_AGENT,
-      // Client-Id is intentionally omitted for Spade.
-      ...(cookieHeader ? { Cookie: cookieHeader } : {}),
+    const g64 = gzipSync(Buffer.from(JSON.stringify(eventPayload), "utf8")).toString("base64");
+    const body = {
+      query:
+        "\n mutation SendEvents($input: SendSpadeEventsInput!) {\n sendSpadeEvents(input: $input) {\n statusCode\n}\n}\n",
+      variables: {
+        input: { data: g64, repository: "twilight", encoding: "GZIP_B64" },
+      },
     };
 
-    this.debug("Watch ping request", {
-      url: spadeUrl,
-      headers: headers.Cookie ? { ...headers, Cookie: "<redacted>" } : headers,
-      bodyLength: formBody.length,
+    this.debug("Watch ping (SendEvents) start", {
+      login,
+      channelId: String(channelId),
+      broadcastId: String(broadcastId),
+      streamId: payload.streamId ?? streamInfo.streamId,
+      game: streamInfo.gameName ?? "",
+      userId: validate.userId,
     });
 
-    const res = await fetch(spadeUrl, {
-      method: "POST",
-      headers,
-      body: formBody,
-    });
-
-    if (res.status === 204) {
-      this.debug("Watch ping ok", { login, channelId, broadcastId });
+    const res = await this.gqlRequest<{
+      data?: { sendSpadeEvents?: { statusCode?: number } };
+    }>(body, "SendEvents");
+    const statusCode = res?.data?.sendSpadeEvents?.statusCode;
+    if (statusCode === 204 || statusCode === 200) {
+      this.debug("Watch ping ok", {
+        login,
+        channelId: String(channelId),
+        broadcastId: String(broadcastId),
+        statusCode,
+      });
       return { ok: true };
     }
 
-    const text = await res.text();
     this.debug("Watch ping failed", {
-      status: res.status,
       login,
-      channelId,
-      broadcastId,
-      body: text,
+      channelId: String(channelId),
+      broadcastId: String(broadcastId),
+      statusCode,
+      response: res,
     });
     throw new TwitchServiceError(
       TWITCH_ERROR_CODES.WATCH_PING_FAILED,
-      text ? `Watch ping failed: ${text}` : `Watch ping failed (${res.status})`,
+      `Watch ping failed (sendSpadeEvents statusCode=${statusCode ?? "unknown"})`,
     );
   }
 

--- a/src/main/twitch/service.ts
+++ b/src/main/twitch/service.ts
@@ -555,7 +555,14 @@ export class TwitchService {
       channelId: session.channel?.id ? String(session.channel.id) : undefined,
       gameName: session.game?.name ?? session.game?.displayName ?? undefined,
     };
-    this.debug("dropProgress: parsed", result);
+    // Surface the queried vs. returned channel: dropCurrentSession returns the
+    // globally-active session, so when these differ the session is for another
+    // channel (stale for us) and the renderer ignores it.
+    this.debug("dropProgress: parsed", {
+      ...result,
+      queriedChannelId: watchedChannelId,
+      channelMatches: !result.channelId || result.channelId === watchedChannelId,
+    });
     return result;
   }
 

--- a/src/main/twitch/service.ts
+++ b/src/main/twitch/service.ts
@@ -1,11 +1,9 @@
 import { gzipSync } from "node:zlib";
 import type { SessionData } from "../core/storage";
-import { TWITCH_WEB_USER_AGENT } from "../config";
 import { TwitchClient, TwitchAuthError, type RevalidateResult, type TwitchUser } from "./client";
 import { buildPriorityPlan, type PriorityPlan } from "./channels";
 import { TwitchServiceError } from "./errors";
 import { TWITCH_ERROR_CODES } from "../../shared/errorCodes";
-import { extractSpadeUrl, SETTINGS_PATTERN } from "./spade";
 import {
   buildCampaignSummaries,
   collectBlockingReasonHints,
@@ -300,65 +298,11 @@ export class TwitchService {
     return { ok: true, status, claimId };
   }
 
-  private spadeCache = new Map<string, string>();
-
   private async buildClaimId(dropId?: string, campaignId?: string): Promise<string | null> {
     if (!dropId || !campaignId) return null;
     const validate = await this.client.getValidateInfo();
     if (!validate?.userId) return null;
     return `${validate.userId}#${campaignId}#${dropId}`;
-  }
-
-  private async resolveSpadeUrl(login: string): Promise<string> {
-    if (this.spadeCache.has(login)) {
-      return this.spadeCache.get(login)!;
-    }
-
-    const fetchText = async (url: string) => {
-      const res = await fetch(url, {
-        redirect: "follow",
-        headers: {
-          "User-Agent": TWITCH_WEB_USER_AGENT,
-        },
-      });
-      if (!res.ok) {
-        throw new TwitchServiceError(
-          TWITCH_ERROR_CODES.SPADE_FETCH_FAILED,
-          `Spade fetch failed (${res.status})`,
-        );
-      }
-      return await res.text();
-    };
-
-    let html: string;
-    try {
-      html = await fetchText(`https://www.twitch.tv/${login}`);
-    } catch (err) {
-      if (err instanceof TwitchServiceError) {
-        throw err;
-      }
-      throw new TwitchServiceError(
-        TWITCH_ERROR_CODES.SPADE_FETCH_FAILED,
-        "Spade fetch failed",
-        err,
-      );
-    }
-
-    let spade = extractSpadeUrl(html);
-    if (!spade) {
-      const settingsMatch = html.match(SETTINGS_PATTERN);
-      if (!settingsMatch) {
-        throw new TwitchServiceError(TWITCH_ERROR_CODES.SPADE_URL_MISSING, "Spade URL missing");
-      }
-      const settingsJs = await fetchText(settingsMatch[1]);
-      spade = extractSpadeUrl(settingsJs);
-      if (!spade) {
-        throw new TwitchServiceError(TWITCH_ERROR_CODES.SPADE_URL_MISSING, "Spade URL missing");
-      }
-    }
-
-    this.spadeCache.set(login, spade);
-    return spade;
   }
 
   private async fetchStreamInfo(login: string): Promise<{

--- a/src/main/twitch/serviceUtils.ts
+++ b/src/main/twitch/serviceUtils.ts
@@ -201,6 +201,11 @@ export type VideoPlayerStreamInfoOverlayChannelResponse = {
   data?: {
     user?: {
       id?: string;
+      // The game lives under broadcastSettings (what TDM reads), not stream.
+      broadcastSettings?: {
+        title?: string;
+        game?: { id?: string | number; name?: string; displayName?: string } | null;
+      } | null;
       stream?: {
         id?: string;
         game?: { id?: string | number; name?: string; displayName?: string } | null;

--- a/src/main/twitch/serviceUtils.ts
+++ b/src/main/twitch/serviceUtils.ts
@@ -203,6 +203,7 @@ export type VideoPlayerStreamInfoOverlayChannelResponse = {
       id?: string;
       stream?: {
         id?: string;
+        game?: { id?: string | number; name?: string; displayName?: string } | null;
         stream?: {
           id?: string;
         };

--- a/src/main/twitch/serviceUtils.ts
+++ b/src/main/twitch/serviceUtils.ts
@@ -150,6 +150,21 @@ export type CampaignsResponse = {
   };
 };
 
+export type DropCurrentSessionResponse = {
+  data?: {
+    currentUser?: {
+      id?: string;
+      dropCurrentSession?: {
+        dropID?: string;
+        currentMinutesWatched?: number;
+        requiredMinutesWatched?: number;
+        channel?: { id?: string | number; name?: string };
+        game?: { id?: string | number; name?: string; displayName?: string };
+      } | null;
+    } | null;
+  };
+};
+
 export type InventoryResponse = {
   data?: {
     currentUser?: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -103,6 +103,7 @@ const api = {
       ipcRenderer.invoke("twitch/debugEmitUserPubSubEvent", payload),
     watch: (payload: { channelId: string; login: string; streamId?: string }) =>
       ipcRenderer.invoke("twitch/watch", payload),
+    dropProgress: () => ipcRenderer.invoke("twitch/dropProgress"),
     claimDrop: (payload: { dropInstanceId?: string; dropId?: string; campaignId?: string }) =>
       ipcRenderer.invoke("twitch/claimDrop", payload),
     onChannelsDiff: (handler: (payload: ChannelsDiffPayload) => void) => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -103,7 +103,8 @@ const api = {
       ipcRenderer.invoke("twitch/debugEmitUserPubSubEvent", payload),
     watch: (payload: { channelId: string; login: string; streamId?: string }) =>
       ipcRenderer.invoke("twitch/watch", payload),
-    dropProgress: () => ipcRenderer.invoke("twitch/dropProgress"),
+    dropProgress: (payload: { channelId: string }) =>
+      ipcRenderer.invoke("twitch/dropProgress", payload),
     claimDrop: (payload: { dropInstanceId?: string; dropId?: string; campaignId?: string }) =>
       ipcRenderer.invoke("twitch/claimDrop", payload),
     onChannelsDiff: (handler: (payload: ChannelsDiffPayload) => void) => {

--- a/src/renderer/features/control/ControlView.tsx
+++ b/src/renderer/features/control/ControlView.tsx
@@ -265,14 +265,12 @@ export function ControlView(props: ControlProps) {
         activeLoginMismatch={state.activeLoginMismatch}
         activeDropTitle={activeDropInfo?.title ?? null}
         activeDropEarnedMinutes={
-          // Use raw earnedMinutes (last inventory snapshot) + the live-ticking
-          // activeElapsedMinutesRaw (seconds since progressAnchorAt, updated 1s).
-          // Do NOT use virtualEarned here — it already bakes in elapsed time
-          // since the anchor, which would double-count when added to
-          // activeElapsedMinutesRaw (both measure from the same base).
-          activeDropInfo
-            ? activeDropInfo.earnedMinutes + state.liveProgress.activeElapsedMinutesRaw
-            : 0
+          // Single source of truth: virtualEarned already = earnedMinutes + the
+          // watch-session-clamped live delta (computed once in useTargetDrops).
+          // Using it directly keeps ControlView identical to the Overview Hero +
+          // Queue, instead of re-deriving progress from a second anchor that
+          // diverged after watch start / stale-inventory windows.
+          activeDropInfo ? activeDropInfo.virtualEarned : 0
         }
         activeDropRequiredMinutes={activeDropInfo?.requiredMinutes ?? 0}
         activeEtaText={state.activeEtaText}

--- a/src/renderer/features/overview/HeroPanel.tsx
+++ b/src/renderer/features/overview/HeroPanel.tsx
@@ -13,6 +13,12 @@ export type HeroPanelProps = {
   activeDropEta?: number | null;
   activeDropRemainingMinutes?: number;
   targetProgress: number;
+  /**
+   * The active drop's own completion %. When present it drives the "% complete"
+   * + bar so they match the card's title + ETA (all about the active drop).
+   * Falls back to the aggregate targetProgress when nothing is being watched.
+   */
+  activeDropProgress?: number | null;
   claimableDrops: number;
   channelsCount: number;
   totalDrops: number;
@@ -32,6 +38,7 @@ export function HeroPanel({
   activeDropEta,
   activeDropRemainingMinutes,
   targetProgress,
+  activeDropProgress,
   claimableDrops,
   channelsCount,
   totalDrops,
@@ -63,7 +70,7 @@ export function HeroPanel({
   }, [activeDropEta]);
 
   const etaText = formatRemainingFromEta(activeDropEta, activeDropRemainingMinutes, now);
-  const progressPct = Math.max(0, Math.min(100, Math.round(targetProgress)));
+  const progressPct = Math.max(0, Math.min(100, Math.round(activeDropProgress ?? targetProgress)));
   const openDrops = Math.max(0, totalDrops - claimedDrops);
   const hasClaimable = claimableDrops > 0;
   const title = activeDropTitle?.trim() || activeGame || t("hero.noActiveTarget");
@@ -109,13 +116,19 @@ export function HeroPanel({
           style={{ gridTemplateColumns: "1.4fr 1fr 1fr 1fr" }}
         >
           <div className="pr-4">
-            <Stat label={t("hero.stat.eta")} value={etaText} sub={t("hero.stat.percentComplete", { pct: progressPct })} accent />
+            <Stat
+              label={t("hero.stat.eta")}
+              value={etaText}
+              sub={t("hero.stat.percentComplete", { pct: progressPct })}
+              accent
+            />
             <div className="mt-2.5 h-[3px] rounded-[2px] bg-[color:var(--dp-border)] overflow-hidden">
               <div
                 className="h-full rounded-[2px]"
                 style={{
                   width: `${progressPct}%`,
-                  background: "linear-gradient(90deg, var(--dp-accent), color-mix(in srgb, var(--dp-accent) 60%, white))",
+                  background:
+                    "linear-gradient(90deg, var(--dp-accent), color-mix(in srgb, var(--dp-accent) 60%, white))",
                   boxShadow: "0 0 12px var(--dp-accent-glow)",
                 }}
               />
@@ -154,7 +167,8 @@ export function HeroPanel({
                     : t("hero.title.claimNowReady")
             }
           >
-            <Check size={11} strokeWidth={2.2} /> {claiming ? t("hero.button.claiming") : t("hero.button.claimNow")}
+            <Check size={11} strokeWidth={2.2} />{" "}
+            {claiming ? t("hero.button.claiming") : t("hero.button.claimNow")}
           </Button>
           <Button
             variant="dp-secondary"
@@ -195,7 +209,7 @@ export function HeroPanel({
             {claimStatus.kind === "success" && claimStatus.message
               ? claimStatus.message
               : claimStatus.kind === "error"
-                ? claimStatus.message ?? t("hero.claimFeedback.errorFallback")
+                ? (claimStatus.message ?? t("hero.claimFeedback.errorFallback"))
                 : null}
           </div>
         )}

--- a/src/renderer/features/overview/QueuePanel.tsx
+++ b/src/renderer/features/overview/QueuePanel.tsx
@@ -13,6 +13,7 @@ import { formatHourMinute, formatPercent, padRank } from "./formatters";
 import { useI18n } from "@renderer/shared/i18n";
 import { cn } from "@renderer/shared/lib/utils";
 import { sameGameName } from "@renderer/shared/domain/gameName";
+import { InventoryDrop } from "@renderer/shared/domain/dropDomain";
 
 export type QueuePanelProps = {
   items: InventoryItem[];
@@ -43,8 +44,15 @@ export function QueuePanel({
   const { t } = useI18n();
   const hasTarget = !!targetGame && targetGame.length > 0;
   const queued = React.useMemo(() => {
+    const now = Date.now();
     const filtered = items.filter((it) => {
       if (it.status === "claimed") return false;
+      // Exclude drops whose campaign has already ended. The queue answers "what
+      // can I still farm" — expired campaigns can't earn. They're also the cause
+      // of the duplicate-looking list: an old + current campaign for the same
+      // game often reuse generic drop names ("Drop 1..4"), so without this the
+      // expired set shows alongside the active one.
+      if (new InventoryDrop(it).isExpired(now)) return false;
       if (hasTarget && !sameGameName(it.game, targetGame)) return false;
       return true;
     });
@@ -73,7 +81,13 @@ export function QueuePanel({
   // most things out.
   const otherGamesCount = React.useMemo(() => {
     if (!hasTarget) return 0;
-    return items.filter((it) => it.status !== "claimed" && !sameGameName(it.game, targetGame)).length;
+    const now = Date.now();
+    return items.filter(
+      (it) =>
+        it.status !== "claimed" &&
+        !new InventoryDrop(it).isExpired(now) &&
+        !sameGameName(it.game, targetGame),
+    ).length;
   }, [items, hasTarget, targetGame]);
 
   return (

--- a/src/renderer/features/settings/SettingsView.tsx
+++ b/src/renderer/features/settings/SettingsView.tsx
@@ -14,6 +14,8 @@ import { useI18n } from "@renderer/shared/i18n";
 
 type SettingsProps = {
   isLinked: boolean;
+  onLogout: () => void;
+  onLogin: () => void;
   language: "de" | "en";
   setLanguage: (val: "de" | "en") => void;
   theme: ThemePreference;
@@ -105,7 +107,9 @@ export function SettingsView(props: SettingsProps) {
     { key: "general", label: t("settings.section.general.sidebar") },
     { key: "engine", label: t("settings.section.engine.sidebar") },
     { key: "appearance", label: t("settings.section.appearance.sidebar") },
-    ...(props.showUpdateCheck ? [{ key: "updates" as SettingsSectionKey, label: t("settings.section.updates.sidebar") }] : []),
+    ...(props.showUpdateCheck
+      ? [{ key: "updates" as SettingsSectionKey, label: t("settings.section.updates.sidebar") }]
+      : []),
     { key: "alerts", label: t("settings.section.alerts.sidebar") },
     { key: "account", label: t("settings.section.account.sidebar") },
     { key: "advanced", label: t("settings.section.advanced.sidebar") },
@@ -213,6 +217,8 @@ export function SettingsView(props: SettingsProps) {
           {active === "account" && (
             <AccountSection
               isLinked={props.isLinked}
+              onLogout={props.onLogout}
+              onLogin={props.onLogin}
               allowUnlinkedGames={props.allowUnlinkedGames}
               setAllowUnlinkedGames={props.setAllowUnlinkedGames}
             />

--- a/src/renderer/features/settings/sections/AccountSection.tsx
+++ b/src/renderer/features/settings/sections/AccountSection.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { Pill } from "@renderer/shared/components/ui/pill";
+import { Button } from "@renderer/shared/components/ui/button";
 import { SectionLabel } from "@renderer/shared/components/ui/section-label";
 import { SettingRow } from "../SettingRow";
 import { SettingsToggle } from "../SettingsToggle";
@@ -7,6 +8,8 @@ import { useI18n } from "@renderer/shared/i18n";
 
 export type AccountSectionProps = {
   isLinked: boolean;
+  onLogout: () => void;
+  onLogin: () => void;
   allowUnlinkedGames: boolean;
   setAllowUnlinkedGames: (val: boolean) => void;
 };
@@ -20,11 +23,24 @@ export function AccountSection(props: AccountSectionProps) {
         label={t("settings.row.connectionStatus.label")}
         description={t("settings.row.connectionStatus.description")}
         control={
-          <div>
+          <div className="flex items-center gap-3">
             {props.isLinked ? (
-              <Pill tone="ok" dot>{t("settings.account.linked")}</Pill>
+              <Pill tone="ok" dot>
+                {t("settings.account.linked")}
+              </Pill>
             ) : (
-              <Pill tone="warn" dot>{t("settings.account.notLinked")}</Pill>
+              <Pill tone="warn" dot>
+                {t("settings.account.notLinked")}
+              </Pill>
+            )}
+            {props.isLinked ? (
+              <Button variant="dp-outline" size="dp-sm" onClick={props.onLogout}>
+                {t("settings.account.logout")}
+              </Button>
+            ) : (
+              <Button variant="dp-primary" size="dp-sm" onClick={props.onLogin}>
+                {t("settings.account.login")}
+              </Button>
             )}
           </div>
         }

--- a/src/renderer/shared/hooks/app/useAppModel.ts
+++ b/src/renderer/shared/hooks/app/useAppModel.ts
@@ -353,6 +353,24 @@ export function useAppModel() {
     });
   }, [watching]);
 
+  // Stamp when the current watch session (channel+stream) began so useTargetDrops
+  // can clamp its live-progress anchor to it — we must not credit elapsed time
+  // from before the user started watching (e.g. a stale inventory snapshot).
+  // Same session-key semantics ControlView uses, so both views agree.
+  const watchSessionKeyRef = useRef<string | null>(null);
+  const [watchStartedAt, setWatchStartedAt] = useState<number | null>(null);
+  useEffect(() => {
+    if (!watching) {
+      watchSessionKeyRef.current = null;
+      setWatchStartedAt(null);
+      return;
+    }
+    const sessionKey = `${watching.id}:${watching.streamId ?? ""}`;
+    if (watchSessionKeyRef.current === sessionKey) return;
+    watchSessionKeyRef.current = sessionKey;
+    setWatchStartedAt(Date.now());
+  }, [watching]);
+
   const { stats, bumpStats, resetStats } = useStats({ demoMode });
   const { notify } = useSmartAlerts({
     enabled: alertsEnabled,
@@ -703,6 +721,7 @@ export function useAppModel() {
     watching,
     inventoryFetchedAt,
     progressAnchorByDropId,
+    watchStartedAt,
   });
 
   useEffect(() => {
@@ -1529,6 +1548,19 @@ export function useAppModel() {
     watchEngineSnapshot,
   };
 
+  // The active drop's own live completion %, so the Hero card's "% complete"
+  // matches its title + ETA (which are both about the active drop). Falls back
+  // to the aggregate targetProgress when nothing is actively being watched.
+  const activeDropProgress =
+    activeDropInfo && activeDropInfo.requiredMinutes > 0
+      ? Math.max(
+          0,
+          Math.min(
+            100,
+            Math.round((activeDropInfo.virtualEarned / activeDropInfo.requiredMinutes) * 100),
+          ),
+        )
+      : null;
   const heroProps = {
     demoMode,
     nextWatchAt: watchStats.nextAt || undefined,
@@ -1544,6 +1576,7 @@ export function useAppModel() {
     inventoryFetchedAt,
     lastWatchOk: watchStats.lastOk || undefined,
     targetProgress,
+    activeDropProgress,
     warmupActive: warmupState.active,
     warmupGame: warmupState.game,
     onClaimNow: claimNowAll,

--- a/src/renderer/shared/hooks/app/useAppModel.ts
+++ b/src/renderer/shared/hooks/app/useAppModel.ts
@@ -380,6 +380,7 @@ export function useAppModel() {
     setClaimStatus,
     withCategories,
     claimNowAll,
+    pollDropProgressOnce,
   } = useInventory(
     isLinkedOrDemo,
     {
@@ -403,6 +404,25 @@ export function useAppModel() {
   });
   const watchStats = useWatchPing({ watching, bumpStats, forwardAuthError, demoMode });
   const stallCheckHeartbeat = watchStats.nextAt;
+
+  // Live drop-progress polling. The `user-drop-events` PubSub topic is dead
+  // (accepts LISTEN but never delivers drop-progress), so we poll the
+  // DropCurrentSessionContext GQL query while watching to read the server-side
+  // minutes accrued by the spade watch pings. ~45s cadence — frequent enough
+  // to feel live, light enough to stay under the radar. Fires an immediate
+  // poll on watch start, then on the interval. No-ops when not watching.
+  const DROP_PROGRESS_POLL_MS = 45_000;
+  const isWatchingForPoll = Boolean(watching) && !demoMode;
+  useEffect(() => {
+    if (!isWatchingForPoll) return;
+    // Immediate poll so the user sees progress shortly after starting, not
+    // only after the first full interval.
+    void pollDropProgressOnce();
+    const id = window.setInterval(() => {
+      void pollDropProgressOnce();
+    }, DROP_PROGRESS_POLL_MS);
+    return () => window.clearInterval(id);
+  }, [isWatchingForPoll, pollDropProgressOnce]);
   const warmupState = useCampaignWarmup({
     allowWatching: allowWarmup,
     demoMode,

--- a/src/renderer/shared/hooks/app/useAppModel.ts
+++ b/src/renderer/shared/hooks/app/useAppModel.ts
@@ -381,6 +381,7 @@ export function useAppModel() {
     withCategories,
     claimNowAll,
     pollDropProgressOnce,
+    pollDropProgressIfStale,
   } = useInventory(
     isLinkedOrDemo,
     {
@@ -405,13 +406,17 @@ export function useAppModel() {
   const watchStats = useWatchPing({ watching, bumpStats, forwardAuthError, demoMode });
   const stallCheckHeartbeat = watchStats.nextAt;
 
-  // Live drop-progress polling. The `user-drop-events` PubSub topic is dead
-  // (accepts LISTEN but never delivers drop-progress), so we poll the
-  // DropCurrentSessionContext GQL query while watching to read the server-side
-  // minutes accrued by the spade watch pings. ~45s cadence — frequent enough
-  // to feel live, light enough to stay under the radar. Fires an immediate
-  // poll on watch start, then on the interval. No-ops when not watching.
-  const DROP_PROGRESS_POLL_MS = 45_000;
+  // Live drop-progress reconciliation while watching. The `user-drop-events`
+  // PubSub topic delivers drop-progress only intermittently (goes silent for
+  // long stretches), so we back it with the DropCurrentSessionContext GQL query
+  // — the same query the Twitch web player + TwitchDropsMiner use. Mirroring
+  // TDM, the poll is REACTIVE, not a blind timer: a cheap tick checks whether
+  // the watched drop has been confirmed (by a push event OR a previous poll)
+  // within STALL_MS; only if it's gone stale do we spend a request. So while
+  // events flow we make zero extra calls, and when they're silent we degrade to
+  // ~one poll per stall window. Stays under the radar by construction.
+  const DROP_PROGRESS_TICK_MS = 15_000; // how often we *check* (no request)
+  const DROP_PROGRESS_STALL_MS = 60_000; // poll only after this much silence
   const isWatchingForPoll = Boolean(watching) && !demoMode;
   // The DropCurrentSessionContext query needs the watched channel id. Track it
   // in a ref so the poll always uses the current channel without restarting the
@@ -420,14 +425,15 @@ export function useAppModel() {
   watchingChannelIdRef.current = String(watching?.channelId ?? watching?.id ?? "");
   useEffect(() => {
     if (!isWatchingForPoll) return;
-    // Immediate poll so the user sees progress shortly after starting, not
-    // only after the first full interval.
+    // One unconditional baseline poll on watch start so the user sees progress
+    // shortly after starting (also seeds the stall clock). After that the gate
+    // takes over and only polls when the live data has actually gone stale.
     void pollDropProgressOnce(watchingChannelIdRef.current);
     const id = window.setInterval(() => {
-      void pollDropProgressOnce(watchingChannelIdRef.current);
-    }, DROP_PROGRESS_POLL_MS);
+      void pollDropProgressIfStale(watchingChannelIdRef.current, DROP_PROGRESS_STALL_MS);
+    }, DROP_PROGRESS_TICK_MS);
     return () => window.clearInterval(id);
-  }, [isWatchingForPoll, pollDropProgressOnce]);
+  }, [isWatchingForPoll, pollDropProgressOnce, pollDropProgressIfStale]);
   const warmupState = useCampaignWarmup({
     allowWatching: allowWarmup,
     demoMode,

--- a/src/renderer/shared/hooks/app/useAppModel.ts
+++ b/src/renderer/shared/hooks/app/useAppModel.ts
@@ -413,13 +413,18 @@ export function useAppModel() {
   // poll on watch start, then on the interval. No-ops when not watching.
   const DROP_PROGRESS_POLL_MS = 45_000;
   const isWatchingForPoll = Boolean(watching) && !demoMode;
+  // The DropCurrentSessionContext query needs the watched channel id. Track it
+  // in a ref so the poll always uses the current channel without restarting the
+  // interval (and resetting its timer) every time the user switches channels.
+  const watchingChannelIdRef = useRef<string>("");
+  watchingChannelIdRef.current = String(watching?.channelId ?? watching?.id ?? "");
   useEffect(() => {
     if (!isWatchingForPoll) return;
     // Immediate poll so the user sees progress shortly after starting, not
     // only after the first full interval.
-    void pollDropProgressOnce();
+    void pollDropProgressOnce(watchingChannelIdRef.current);
     const id = window.setInterval(() => {
-      void pollDropProgressOnce();
+      void pollDropProgressOnce(watchingChannelIdRef.current);
     }, DROP_PROGRESS_POLL_MS);
     return () => window.clearInterval(id);
   }, [isWatchingForPoll, pollDropProgressOnce]);
@@ -527,22 +532,18 @@ export function useAppModel() {
     });
   }, [isGameInStallCooldown, stallSuppressedGame, stalledGameCooldownUntil, withCategories]);
 
-  const {
-    activeTargetGame,
-    setActiveTargetGame,
-    priorityOrder,
-    priorityListPreemptionActive,
-  } = usePriorityOrchestration({
-    demoMode,
-    inventoryStatus: inventory.status,
-    inventoryItems,
-    withCategories: orchestrationCategories,
-    priorityGames,
-    obeyPriority,
-    allowUnlinkedGames,
-    watching,
-    stopWatching: stopWatchingForAutomation,
-  });
+  const { activeTargetGame, setActiveTargetGame, priorityOrder, priorityListPreemptionActive } =
+    usePriorityOrchestration({
+      demoMode,
+      inventoryStatus: inventory.status,
+      inventoryItems,
+      withCategories: orchestrationCategories,
+      priorityGames,
+      obeyPriority,
+      allowUnlinkedGames,
+      watching,
+      stopWatching: stopWatchingForAutomation,
+    });
 
   const targetGame = selectVisibleTargetGame(watchEngineState, activeTargetGame);
   const displayTargetGame = useMemo(() => {
@@ -820,9 +821,7 @@ export function useAppModel() {
     prevAddedRef.current = inventoryChanges?.added;
     if (currSize > prevSize && currSize > 0) {
       const firstAddedId = inventoryChanges.added.values().next().value;
-      const sample = firstAddedId
-        ? inventoryItems.find((it) => it.id === firstAddedId)
-        : undefined;
+      const sample = firstAddedId ? inventoryItems.find((it) => it.id === firstAddedId) : undefined;
       recordActivity({
         kind: "new-drops",
         at: Date.now(),

--- a/src/renderer/shared/hooks/app/useAppModel.ts
+++ b/src/renderer/shared/hooks/app/useAppModel.ts
@@ -1455,6 +1455,8 @@ export function useAppModel() {
   };
   const settingsProps = {
     isLinked,
+    onLogout: logout,
+    onLogin: startLogin,
     theme,
     setTheme,
     accent,

--- a/src/renderer/shared/hooks/inventory/useInventory.ts
+++ b/src/renderer/shared/hooks/inventory/useInventory.ts
@@ -535,6 +535,23 @@ export function useInventory(isLinked: boolean, events?: InventoryEvents, opts?:
       lastProgressUpdateAtRef.current = Date.now();
       const progress = res.progress;
       if (!progress) return; // no active session on the watched channel
+      // Twitch's dropCurrentSession returns the user's GLOBALLY-active drop
+      // session, which can still point at a previously-watched channel (frozen
+      // at its last value) right after a channel switch or app restart — it does
+      // NOT scope to the channelID we pass. If the session is for a different
+      // channel than the one we're watching, it's stale for us: applying it would
+      // freeze the active drop on another channel's old minutes (the "stuck at 8,
+      // ETA always ~51" symptom). Ignore it and let the watch-start-anchored
+      // virtualEarned estimate drive the UI until Twitch credits this channel.
+      if (progress.channelId && progress.channelId !== watchedChannelId) {
+        logDebug("inventory: dropProgress ignored — session is for another channel", {
+          watching: watchedChannelId,
+          session: progress.channelId,
+          dropId: progress.dropId,
+          currentMin: progress.currentMinutesWatched,
+        });
+        return;
+      }
       const dropId = progress.dropId?.trim();
       if (!dropId) return;
       const currentMin = Math.max(0, Number(progress.currentMinutesWatched) || 0);

--- a/src/renderer/shared/hooks/inventory/useInventory.ts
+++ b/src/renderer/shared/hooks/inventory/useInventory.ts
@@ -492,6 +492,73 @@ export function useInventory(isLinked: boolean, events?: InventoryEvents, opts?:
     });
   }, [inventory, onAuthError, onClaimed, setClaimStatus]);
 
+  /**
+   * Polls the live drop progress (DropCurrentSessionContext GQL) and patches
+   * it into inventory state — the replacement for the dead `user-drop-events`
+   * PubSub topic. Synthesizes a drop-progress event so it flows through the
+   * exact same applyPubSubEventToInventoryState path the PubSub handler used.
+   *
+   * Called on an interval while watching (see useDropProgressPoll). Safe to
+   * call when idle — it no-ops if not linked or inventory isn't ready.
+   */
+  const pollDropProgressOnce = useCallback(async () => {
+    if (demoMode || !isLinked) return;
+    let res: Awaited<ReturnType<typeof window.electronAPI.twitch.dropProgress>>;
+    try {
+      res = await window.electronAPI.twitch.dropProgress();
+    } catch {
+      return;
+    }
+    if (isIpcAuthErrorResponse(res)) {
+      onAuthError(res.message);
+      return;
+    }
+    if (!res || typeof res !== "object" || !("ok" in res) || !res.ok) return;
+    const progress = res.progress;
+    if (!progress) return; // no active session on the watched channel
+    const dropId = progress.dropId?.trim();
+    if (!dropId) return;
+    const currentMin = Math.max(0, Number(progress.currentMinutesWatched) || 0);
+    const reconciler = pubSubReconcilerRef.current;
+    // Dedupe: skip if the reconciler says this exact progress was already applied.
+    if (reconciler && !reconciler.shouldApplyProgress(dropId, currentMin)) return;
+
+    const synthetic: UserPubSubEvent = {
+      kind: "drop-progress",
+      at: Date.now(),
+      topic: "drop-progress-poll",
+      messageType: "drop-progress",
+      dropId,
+      currentProgressMin: currentMin,
+      requiredProgressMin: Math.max(0, Number(progress.requiredMinutesWatched) || 0),
+    };
+
+    let patchResult: ReturnType<typeof applyPubSubEventToInventoryState> | null = null;
+    setInventory((prev) => {
+      const result = applyPubSubEventToInventoryState(prev, synthetic);
+      if (!result.patched) return prev;
+      patchResult = result;
+      return result.nextInventory;
+    });
+    const applied = patchResult as ReturnType<typeof applyPubSubEventToInventoryState> | null;
+    if (!applied?.patched) return;
+    totalMinutesRef.current = applied.nextTotalMinutes ?? totalMinutesRef.current ?? 0;
+    if (applied.deltaMinutes > 0) onMinutesEarned(applied.deltaMinutes);
+    const anchorIds = getPatchedAnchorIds(applied);
+    if (anchorIds.length > 0) {
+      setProgressAnchorByDropId((prev) => mergeProgressAnchors(prev, anchorIds, synthetic.at));
+    }
+    const updatedId = applied.updatedId;
+    if (updatedId) {
+      setInventoryChanges((prev) => markUpdatedInventoryChange(prev, updatedId));
+    }
+    logDebug("inventory: dropProgress poll applied", {
+      dropId,
+      currentMin,
+      delta: applied.deltaMinutes,
+    });
+  }, [demoMode, isLinked, onAuthError, onMinutesEarned]);
+
   return {
     inventory,
     inventoryItems,
@@ -509,5 +576,6 @@ export function useInventory(isLinked: boolean, events?: InventoryEvents, opts?:
     claimStatus,
     setClaimStatus,
     claimNowAll,
+    pollDropProgressOnce,
   };
 }

--- a/src/renderer/shared/hooks/inventory/useInventory.ts
+++ b/src/renderer/shared/hooks/inventory/useInventory.ts
@@ -501,63 +501,70 @@ export function useInventory(isLinked: boolean, events?: InventoryEvents, opts?:
    * Called on an interval while watching (see useDropProgressPoll). Safe to
    * call when idle — it no-ops if not linked or inventory isn't ready.
    */
-  const pollDropProgressOnce = useCallback(async () => {
-    if (demoMode || !isLinked) return;
-    let res: Awaited<ReturnType<typeof window.electronAPI.twitch.dropProgress>>;
-    try {
-      res = await window.electronAPI.twitch.dropProgress();
-    } catch {
-      return;
-    }
-    if (isIpcAuthErrorResponse(res)) {
-      onAuthError(res.message);
-      return;
-    }
-    if (!res || typeof res !== "object" || !("ok" in res) || !res.ok) return;
-    const progress = res.progress;
-    if (!progress) return; // no active session on the watched channel
-    const dropId = progress.dropId?.trim();
-    if (!dropId) return;
-    const currentMin = Math.max(0, Number(progress.currentMinutesWatched) || 0);
-    const reconciler = pubSubReconcilerRef.current;
-    // Dedupe: skip if the reconciler says this exact progress was already applied.
-    if (reconciler && !reconciler.shouldApplyProgress(dropId, currentMin)) return;
+  const pollDropProgressOnce = useCallback(
+    async (channelId: string) => {
+      if (demoMode || !isLinked) return;
+      const watchedChannelId = String(channelId ?? "").trim();
+      // DropCurrentSessionContext keys off the watched channel id — without it the
+      // server always returns a null session, so there's nothing to poll for.
+      if (!watchedChannelId) return;
+      let res: Awaited<ReturnType<typeof window.electronAPI.twitch.dropProgress>>;
+      try {
+        res = await window.electronAPI.twitch.dropProgress({ channelId: watchedChannelId });
+      } catch {
+        return;
+      }
+      if (isIpcAuthErrorResponse(res)) {
+        onAuthError(res.message);
+        return;
+      }
+      if (!res || typeof res !== "object" || !("ok" in res) || !res.ok) return;
+      const progress = res.progress;
+      if (!progress) return; // no active session on the watched channel
+      const dropId = progress.dropId?.trim();
+      if (!dropId) return;
+      const currentMin = Math.max(0, Number(progress.currentMinutesWatched) || 0);
+      const reconciler = pubSubReconcilerRef.current;
+      // Dedupe: skip if the reconciler says this exact progress was already applied.
+      if (reconciler && !reconciler.shouldApplyProgress(dropId, currentMin)) return;
 
-    const synthetic: UserPubSubEvent = {
-      kind: "drop-progress",
-      at: Date.now(),
-      topic: "drop-progress-poll",
-      messageType: "drop-progress",
-      dropId,
-      currentProgressMin: currentMin,
-      requiredProgressMin: Math.max(0, Number(progress.requiredMinutesWatched) || 0),
-    };
+      const synthetic: UserPubSubEvent = {
+        kind: "drop-progress",
+        at: Date.now(),
+        topic: "drop-progress-poll",
+        messageType: "drop-progress",
+        dropId,
+        currentProgressMin: currentMin,
+        requiredProgressMin: Math.max(0, Number(progress.requiredMinutesWatched) || 0),
+      };
 
-    let patchResult: ReturnType<typeof applyPubSubEventToInventoryState> | null = null;
-    setInventory((prev) => {
-      const result = applyPubSubEventToInventoryState(prev, synthetic);
-      if (!result.patched) return prev;
-      patchResult = result;
-      return result.nextInventory;
-    });
-    const applied = patchResult as ReturnType<typeof applyPubSubEventToInventoryState> | null;
-    if (!applied?.patched) return;
-    totalMinutesRef.current = applied.nextTotalMinutes ?? totalMinutesRef.current ?? 0;
-    if (applied.deltaMinutes > 0) onMinutesEarned(applied.deltaMinutes);
-    const anchorIds = getPatchedAnchorIds(applied);
-    if (anchorIds.length > 0) {
-      setProgressAnchorByDropId((prev) => mergeProgressAnchors(prev, anchorIds, synthetic.at));
-    }
-    const updatedId = applied.updatedId;
-    if (updatedId) {
-      setInventoryChanges((prev) => markUpdatedInventoryChange(prev, updatedId));
-    }
-    logDebug("inventory: dropProgress poll applied", {
-      dropId,
-      currentMin,
-      delta: applied.deltaMinutes,
-    });
-  }, [demoMode, isLinked, onAuthError, onMinutesEarned]);
+      let patchResult: ReturnType<typeof applyPubSubEventToInventoryState> | null = null;
+      setInventory((prev) => {
+        const result = applyPubSubEventToInventoryState(prev, synthetic);
+        if (!result.patched) return prev;
+        patchResult = result;
+        return result.nextInventory;
+      });
+      const applied = patchResult as ReturnType<typeof applyPubSubEventToInventoryState> | null;
+      if (!applied?.patched) return;
+      totalMinutesRef.current = applied.nextTotalMinutes ?? totalMinutesRef.current ?? 0;
+      if (applied.deltaMinutes > 0) onMinutesEarned(applied.deltaMinutes);
+      const anchorIds = getPatchedAnchorIds(applied);
+      if (anchorIds.length > 0) {
+        setProgressAnchorByDropId((prev) => mergeProgressAnchors(prev, anchorIds, synthetic.at));
+      }
+      const updatedId = applied.updatedId;
+      if (updatedId) {
+        setInventoryChanges((prev) => markUpdatedInventoryChange(prev, updatedId));
+      }
+      logDebug("inventory: dropProgress poll applied", {
+        dropId,
+        currentMin,
+        delta: applied.deltaMinutes,
+      });
+    },
+    [demoMode, isLinked, onAuthError, onMinutesEarned],
+  );
 
   return {
     inventory,

--- a/src/renderer/shared/hooks/inventory/useInventory.ts
+++ b/src/renderer/shared/hooks/inventory/useInventory.ts
@@ -86,6 +86,11 @@ export function useInventory(isLinked: boolean, events?: InventoryEvents, opts?:
   const [progressAnchorByDropId, setProgressAnchorByDropId] = useState<Record<string, number>>({});
   const [claimStatus, setClaimStatus] = useState<ClaimStatus | null>(null);
   const totalMinutesRef = useRef<number | null>(null);
+  // Timestamp of the last time the watched drop's progress was confirmed by the
+  // server — either via a PubSub drop-progress event or a successful GQL poll.
+  // Drives TDM-style reactive poll gating: while this stays fresh (events are
+  // flowing, or a poll just ran), we skip polling entirely. 0 = never confirmed.
+  const lastProgressUpdateAtRef = useRef<number>(0);
   const claimEngineRef = useRef<InventoryClaimEngine>(new InventoryClaimEngine());
   const pubSubReconcilerRef = useRef<InventoryPubSubReconciler | null>(null);
   const fetchInFlightRef = useRef(false);
@@ -392,6 +397,10 @@ export function useInventory(isLinked: boolean, events?: InventoryEvents, opts?:
       });
 
       if (payload.kind === "drop-progress") {
+        // A push arrived — the live event channel is alive right now, so reset
+        // the stall clock. This keeps the reactive poll gate quiet while events
+        // flow (mirrors TDM: GQL is only a fallback for when push stalls).
+        lastProgressUpdateAtRef.current = Date.now();
         const dropId = payload.dropId?.trim();
         const progress =
           typeof payload.currentProgressMin === "number" &&
@@ -519,6 +528,11 @@ export function useInventory(isLinked: boolean, events?: InventoryEvents, opts?:
         return;
       }
       if (!res || typeof res !== "object" || !("ok" in res) || !res.ok) return;
+      // We got a definitive server answer — either live progress or a clean
+      // "no active session". Both reset the stall clock so the reactive gate
+      // waits a full window before polling again (a null session shouldn't make
+      // us re-poll every tick).
+      lastProgressUpdateAtRef.current = Date.now();
       const progress = res.progress;
       if (!progress) return; // no active session on the watched channel
       const dropId = progress.dropId?.trim();
@@ -566,6 +580,20 @@ export function useInventory(isLinked: boolean, events?: InventoryEvents, opts?:
     [demoMode, isLinked, onAuthError, onMinutesEarned],
   );
 
+  // TDM-style reactive gate: only spend a GQL poll when the live data has gone
+  // stale — i.e. neither a PubSub drop-progress event nor a previous poll has
+  // confirmed the watched drop within `stallMs`. While push events flow (or
+  // right after a poll), this no-ops and makes zero extra requests; when the
+  // event channel is silent it degrades to ~one poll per stall window.
+  const pollDropProgressIfStale = useCallback(
+    async (channelId: string, stallMs: number) => {
+      const lastAt = lastProgressUpdateAtRef.current;
+      if (lastAt > 0 && Date.now() - lastAt < stallMs) return;
+      await pollDropProgressOnce(channelId);
+    },
+    [pollDropProgressOnce],
+  );
+
   return {
     inventory,
     inventoryItems,
@@ -584,5 +612,6 @@ export function useInventory(isLinked: boolean, events?: InventoryEvents, opts?:
     setClaimStatus,
     claimNowAll,
     pollDropProgressOnce,
+    pollDropProgressIfStale,
   };
 }

--- a/src/renderer/shared/hooks/inventory/useTargetDrops.ts
+++ b/src/renderer/shared/hooks/inventory/useTargetDrops.ts
@@ -45,6 +45,14 @@ type Params = {
   watching: WatchingState;
   inventoryFetchedAt: number | null;
   progressAnchorByDropId?: Record<string, number>;
+  /**
+   * Timestamp when the current watch session (this channel+stream) began. The
+   * live-progress anchor is clamped to never predate this, so we don't credit
+   * elapsed time from before the user actually started watching (e.g. a stale
+   * inventory snapshot). ControlView uses the same clamp — passing it here keeps
+   * both views' live progress identical.
+   */
+  watchStartedAt?: number | null;
 };
 
 type ComputeParams = Params & { now?: number };
@@ -58,6 +66,7 @@ export function computeTargetDrops({
   watching,
   inventoryFetchedAt,
   progressAnchorByDropId,
+  watchStartedAt,
   now: providedNow,
 }: ComputeParams): TargetDropsResult {
   if (!targetGame) {
@@ -105,7 +114,9 @@ export function computeTargetDrops({
   );
   const inProgressRelevant = withCategoryDrops.filter(
     ({ drop, category }) =>
-      sameGameName(drop.game, targetGame) && category === "in-progress" && isWatchableInProgress(drop),
+      sameGameName(drop.game, targetGame) &&
+      category === "in-progress" &&
+      isWatchableInProgress(drop),
   );
   const sortCandidates = (
     candidates: Array<{ drop: InventoryDrop; category: string }>,
@@ -128,7 +139,9 @@ export function computeTargetDrops({
   const sortedInProgress = sortCandidates(inProgressRelevant);
   const upcomingRelevant = withCategoryDrops.filter(
     ({ drop, category }) =>
-      sameGameName(drop.game, targetGame) && category === "upcoming" && isWatchableUpcomingDrop(drop),
+      sameGameName(drop.game, targetGame) &&
+      category === "upcoming" &&
+      isWatchableUpcomingDrop(drop),
   );
   const sortedUpcoming = sortCandidates(upcomingRelevant);
   const sortedActiveItems = sortedActive.map((s) => s.drop);
@@ -246,8 +259,16 @@ export function computeTargetDrops({
   const activeDropAnchorAt = (() => {
     if (!activeDrop || !canPredictActiveDropProgress) return null;
     const byDrop = progressAnchorByDropId?.[activeDrop.id];
-    if (typeof byDrop === "number" && Number.isFinite(byDrop)) return byDrop;
-    return inventoryFetchedAt;
+    const base =
+      typeof byDrop === "number" && Number.isFinite(byDrop) ? byDrop : inventoryFetchedAt;
+    if (base == null) return null;
+    // Clamp to the current watch-session start so we never credit elapsed time
+    // from before the user actually started watching this channel (e.g. a stale
+    // inventory snapshot). Mirrors ControlView so both views show identical live
+    // progress for the active drop.
+    return typeof watchStartedAt === "number" && Number.isFinite(watchStartedAt)
+      ? Math.max(base, watchStartedAt)
+      : base;
   })();
   const liveDeltaMinutesRaw =
     canPredictActiveDropProgress && activeDropAnchorAt
@@ -322,6 +343,7 @@ export function useTargetDrops({
   watching,
   inventoryFetchedAt,
   progressAnchorByDropId,
+  watchStartedAt,
 }: Params): TargetDropsResult {
   // Tick `now` every second while the user is watching the target game so
   // targetProgress, liveDeltaApplied, virtualEarned, and activeDropEta stay
@@ -342,6 +364,7 @@ export function useTargetDrops({
         watching,
         inventoryFetchedAt,
         progressAnchorByDropId,
+        watchStartedAt,
         now: isLiveActive ? nowMs : undefined,
       }),
     [
@@ -350,6 +373,7 @@ export function useTargetDrops({
       inventoryFetchedAt,
       inventoryItems,
       progressAnchorByDropId,
+      watchStartedAt,
       targetGame,
       watching,
       withCategories,

--- a/src/renderer/shared/i18n.tsx
+++ b/src/renderer/shared/i18n.tsx
@@ -610,26 +610,35 @@ const translations: Translations = {
     "settings.subsection.backup": "settings export & import",
 
     // Row labels + descriptions
-    "settings.row.language.description": "Interface language for labels, alerts, and onboarding text.",
-    "settings.row.demoMode.description": "Use synthetic data so you can preview the UI without a Twitch login.",
+    "settings.row.language.description":
+      "Interface language for labels, alerts, and onboarding text.",
+    "settings.row.demoMode.description":
+      "Use synthetic data so you can preview the UI without a Twitch login.",
     "settings.row.sendTestAlert.label": "Send test alert",
-    "settings.row.sendTestAlert.description": "Triggers a desktop notification to verify alerts work on this OS.",
+    "settings.row.sendTestAlert.description":
+      "Triggers a desktop notification to verify alerts work on this OS.",
     "settings.row.autoStart.label": "Launch at login",
-    "settings.row.autoStart.description": "Starts Droppilot automatically when you log into your OS.",
+    "settings.row.autoStart.description":
+      "Starts Droppilot automatically when you log into your OS.",
     "settings.row.closeToTray.label": "Close to tray",
-    "settings.row.closeToTray.description": "Clicking the close button hides Droppilot to the system tray instead of quitting. Use the tray icon's Quit menu to exit.",
+    "settings.row.closeToTray.description":
+      "Clicking the close button hides Droppilot to the system tray instead of quitting. Use the tray icon's Quit menu to exit.",
     "settings.row.minimizeToTray.label": "Minimize to tray",
-    "settings.row.minimizeToTray.description": "Minimizing the window hides it from the taskbar (the tray icon stays available).",
+    "settings.row.minimizeToTray.description":
+      "Minimizing the window hides it from the taskbar (the tray icon stays available).",
     "settings.row.refreshInterval.label": "Channels refresh interval",
-    "settings.row.refreshInterval.description": "How often the channel tracker re-queries Twitch (random jitter between min and max).",
+    "settings.row.refreshInterval.description":
+      "How often the channel tracker re-queries Twitch (random jitter between min and max).",
     "settings.row.resetAutomation.label": "Reset automation flags",
-    "settings.row.resetAutomation.description": "Clears auto-claim, auto-switch, warmup, etc. back to defaults. Does not log you out.",
+    "settings.row.resetAutomation.description":
+      "Clears auto-claim, auto-switch, warmup, etc. back to defaults. Does not log you out.",
     "settings.row.theme.label": "Color scheme",
     "settings.row.theme.description": "Light or dark interface.",
     "settings.row.theme.dark": "Dark",
     "settings.row.theme.light": "Light",
     "settings.row.accent.label": "Accent color",
-    "settings.row.accent.description": "Pick a preset or use the color picker to set a custom accent. The choice tints buttons, pills, and highlights across the app.",
+    "settings.row.accent.description":
+      "Pick a preset or use the color picker to set a custom accent. The choice tints buttons, pills, and highlights across the app.",
     "settings.row.accent.reset": "Reset to default",
     "settings.row.accent.customAria": "Pick a custom accent color",
     "settings.row.accent.swatchAria": "Use {name} accent",
@@ -642,40 +651,54 @@ const translations: Translations = {
     "settings.row.accent.preset.rose": "Rose",
     "settings.row.accent.preset.slate": "Slate",
     "settings.row.fontPair.label": "Font pair",
-    "settings.row.fontPair.description": "Switch the sans + monospace font pair used throughout the app. Non-default pairs lazy-load from Google Fonts on first use.",
+    "settings.row.fontPair.description":
+      "Switch the sans + monospace font pair used throughout the app. Non-default pairs lazy-load from Google Fonts on first use.",
     "settings.row.fontPair.preset.proConsole": "Pro Console (default)",
     "settings.row.fontPair.preset.modern": "Modern (Inter + JetBrains Mono)",
     "settings.row.fontPair.preset.geist": "Geist (Geist + Geist Mono)",
     "settings.row.fontPair.preset.system": "System (zero network)",
-    "settings.row.badgesEmotes.description": "Display Twitch badges and emotes in chat-like elements.",
+    "settings.row.badgesEmotes.description":
+      "Display Twitch badges and emotes in chat-like elements.",
     "settings.row.updateChannel.description": "Switch between stable and pre-release releases.",
     "settings.row.updateStatus.label": "Status",
-    "settings.row.updateStatus.description": "Last known update status reported by the auto-updater.",
+    "settings.row.updateStatus.description":
+      "Last known update status reported by the auto-updater.",
     "settings.row.updateActions.label": "Actions",
     "settings.row.updateActions.description": "Manually trigger a check, download, or install.",
     "settings.row.alertsEnabled.label": "Desktop alerts",
-    "settings.row.alertsEnabled.description": "Master toggle. When off, no notifications are sent regardless of the per-event settings below.",
+    "settings.row.alertsEnabled.description":
+      "Master toggle. When off, no notifications are sent regardless of the per-event settings below.",
     "settings.row.alertsNotifyWhileFocused.label": "Notify while the app is focused",
-    "settings.row.alertsNotifyWhileFocused.description": "Show notifications even when Droppilot is the active window.",
+    "settings.row.alertsNotifyWhileFocused.description":
+      "Show notifications even when Droppilot is the active window.",
     "settings.row.alertsDropClaimed.label": "Drop claimed",
     "settings.row.alertsDropClaimed.description": "A drop you were watching for has been claimed.",
     "settings.row.alertsDropEndingSoon.label": "Drop ending soon",
-    "settings.row.alertsDropEndingSoon.description": "A drop is close to expiring. Warn you N minutes before.",
+    "settings.row.alertsDropEndingSoon.description":
+      "A drop is close to expiring. Warn you N minutes before.",
     "settings.row.alertsDropEndingMinutes.label": "Ending-soon threshold",
-    "settings.row.alertsDropEndingMinutes.description": "How many minutes before expiry the warning fires.",
+    "settings.row.alertsDropEndingMinutes.description":
+      "How many minutes before expiry the warning fires.",
     "settings.row.alertsNewDrops.label": "New drops available",
-    "settings.row.alertsNewDrops.description": "A new campaign or drop just dropped (pun intended).",
+    "settings.row.alertsNewDrops.description":
+      "A new campaign or drop just dropped (pun intended).",
     "settings.row.alertsWatchError.label": "Watch errors",
-    "settings.row.alertsWatchError.description": "Watcher failed (auth expired, network issue, etc.).",
+    "settings.row.alertsWatchError.description":
+      "Watcher failed (auth expired, network issue, etc.).",
     "settings.row.alertsAutoSwitch.label": "Auto-switch happened",
-    "settings.row.alertsAutoSwitch.description": "The watch engine moved to a different channel automatically.",
+    "settings.row.alertsAutoSwitch.description":
+      "The watch engine moved to a different channel automatically.",
     "settings.row.connectionStatus.label": "Connection status",
-    "settings.row.connectionStatus.description": "Logout and re-login from the top-right of the title bar.",
-    "settings.row.allowUnlinked.description": "Show drops for games where you haven't linked the Twitch account to the game account yet. They won't progress without linking.",
+    "settings.row.connectionStatus.description":
+      "Log out to switch accounts or refresh your Twitch session.",
+    "settings.row.allowUnlinked.description":
+      "Show drops for games where you haven't linked the Twitch account to the game account yet. They won't progress without linking.",
     "settings.row.debugView.label": "Show Debug view",
-    "settings.row.debugView.description": "Adds a 'debug' tab to the top nav with logs, perf snapshots, and a state dump.",
+    "settings.row.debugView.description":
+      "Adds a 'debug' tab to the top nav with logs, perf snapshots, and a state dump.",
     "settings.row.settingsJson.label": "Settings JSON",
-    "settings.row.settingsJson.description": "Paste a JSON blob and click Import, or click Export to copy your current settings.",
+    "settings.row.settingsJson.description":
+      "Paste a JSON blob and click Import, or click Export to copy your current settings.",
 
     // Buttons
     "settings.button.sendTest": "send test",
@@ -710,6 +733,9 @@ const translations: Translations = {
     // Account pills
     "settings.account.linked": "linked",
     "settings.account.notLinked": "not linked",
+    "settings.account.logout": "Log out",
+    "settings.account.login": "Connect account",
+    "settings.account.loggingIn": "Connecting…",
 
     // Tracker (used in EngineStatusPanel, prep for T03)
     "control.tracker.label": "tracker",
@@ -917,7 +943,8 @@ const translations: Translations = {
     "control.activeSession.live": "live",
     "control.activeSession.paused": "paused",
     "control.activeSession.activeDrop": "active drop",
-    "control.activeSession.watchedRequiredEta": "{watched} watched · {required} required · eta {eta}",
+    "control.activeSession.watchedRequiredEta":
+      "{watched} watched · {required} required · eta {eta}",
     "control.activeSession.watchedRequired": "{watched} watched · {required} required",
     "control.activeSession.noFarmable": "no farmable drop on this channel",
     "control.activeSession.engineIdle": "engine idle",
@@ -1573,26 +1600,34 @@ const translations: Translations = {
     "settings.subsection.gameLinking": "spiel-verknüpfung",
     "settings.subsection.backup": "einstellungen export & import",
 
-    "settings.row.language.description": "Sprache für Labels, Benachrichtigungen und Onboarding-Texte.",
-    "settings.row.demoMode.description": "Verwendet synthetische Daten, damit du die UI ohne Twitch-Login ausprobieren kannst.",
+    "settings.row.language.description":
+      "Sprache für Labels, Benachrichtigungen und Onboarding-Texte.",
+    "settings.row.demoMode.description":
+      "Verwendet synthetische Daten, damit du die UI ohne Twitch-Login ausprobieren kannst.",
     "settings.row.sendTestAlert.label": "Test-Benachrichtigung senden",
-    "settings.row.sendTestAlert.description": "Triggert eine Desktop-Benachrichtigung, um Alerts auf diesem OS zu prüfen.",
+    "settings.row.sendTestAlert.description":
+      "Triggert eine Desktop-Benachrichtigung, um Alerts auf diesem OS zu prüfen.",
     "settings.row.autoStart.label": "Beim Login starten",
     "settings.row.autoStart.description": "Startet Droppilot automatisch beim OS-Login.",
     "settings.row.closeToTray.label": "Beim Schließen ins Tray",
-    "settings.row.closeToTray.description": "Klick auf Schließen blendet Droppilot in den Tray statt zu beenden. Über das Tray-Icon kannst du komplett beenden.",
+    "settings.row.closeToTray.description":
+      "Klick auf Schließen blendet Droppilot in den Tray statt zu beenden. Über das Tray-Icon kannst du komplett beenden.",
     "settings.row.minimizeToTray.label": "Beim Minimieren ins Tray",
-    "settings.row.minimizeToTray.description": "Minimieren blendet das Fenster aus der Taskleiste (Tray-Icon bleibt verfügbar).",
+    "settings.row.minimizeToTray.description":
+      "Minimieren blendet das Fenster aus der Taskleiste (Tray-Icon bleibt verfügbar).",
     "settings.row.refreshInterval.label": "Channel-Refresh-Intervall",
-    "settings.row.refreshInterval.description": "Wie oft der Channel-Tracker Twitch neu abfragt (zufälliger Jitter zwischen Min und Max).",
+    "settings.row.refreshInterval.description":
+      "Wie oft der Channel-Tracker Twitch neu abfragt (zufälliger Jitter zwischen Min und Max).",
     "settings.row.resetAutomation.label": "Automatisierung zurücksetzen",
-    "settings.row.resetAutomation.description": "Setzt auto-claim, auto-switch, warmup etc. auf die Defaults zurück. Loggt dich nicht aus.",
+    "settings.row.resetAutomation.description":
+      "Setzt auto-claim, auto-switch, warmup etc. auf die Defaults zurück. Loggt dich nicht aus.",
     "settings.row.theme.label": "Farbschema",
     "settings.row.theme.description": "Helles oder dunkles Interface.",
     "settings.row.theme.dark": "Dunkel",
     "settings.row.theme.light": "Hell",
     "settings.row.accent.label": "Akzentfarbe",
-    "settings.row.accent.description": "Wähle ein Preset oder nutze den Color-Picker für einen eigenen Akzent. Die Farbe färbt Buttons, Pills und Highlights in der ganzen App ein.",
+    "settings.row.accent.description":
+      "Wähle ein Preset oder nutze den Color-Picker für einen eigenen Akzent. Die Farbe färbt Buttons, Pills und Highlights in der ganzen App ein.",
     "settings.row.accent.reset": "Auf Standard zurücksetzen",
     "settings.row.accent.customAria": "Eigene Akzentfarbe wählen",
     "settings.row.accent.swatchAria": "{name}-Akzent verwenden",
@@ -1605,40 +1640,55 @@ const translations: Translations = {
     "settings.row.accent.preset.rose": "Rosa",
     "settings.row.accent.preset.slate": "Schiefer",
     "settings.row.fontPair.label": "Schriftpaar",
-    "settings.row.fontPair.description": "Wechsle das Sans- + Monospace-Schriftpaar der App. Nicht-Standard-Paare werden bei der ersten Auswahl lazy von Google Fonts geladen.",
+    "settings.row.fontPair.description":
+      "Wechsle das Sans- + Monospace-Schriftpaar der App. Nicht-Standard-Paare werden bei der ersten Auswahl lazy von Google Fonts geladen.",
     "settings.row.fontPair.preset.proConsole": "Pro Console (Standard)",
     "settings.row.fontPair.preset.modern": "Modern (Inter + JetBrains Mono)",
     "settings.row.fontPair.preset.geist": "Geist (Geist + Geist Mono)",
     "settings.row.fontPair.preset.system": "System (kein Netzwerk)",
-    "settings.row.badgesEmotes.description": "Twitch-Badges und Emotes in Chat-ähnlichen Elementen anzeigen.",
-    "settings.row.updateChannel.description": "Zwischen stabilen und Pre-Release-Versionen wechseln.",
+    "settings.row.badgesEmotes.description":
+      "Twitch-Badges und Emotes in Chat-ähnlichen Elementen anzeigen.",
+    "settings.row.updateChannel.description":
+      "Zwischen stabilen und Pre-Release-Versionen wechseln.",
     "settings.row.updateStatus.label": "Status",
     "settings.row.updateStatus.description": "Letzter bekannter Update-Status vom Auto-Updater.",
     "settings.row.updateActions.label": "Aktionen",
     "settings.row.updateActions.description": "Manuell Check, Download oder Installation auslösen.",
     "settings.row.alertsEnabled.label": "Desktop-Benachrichtigungen",
-    "settings.row.alertsEnabled.description": "Hauptschalter. Wenn aus, werden keine Benachrichtigungen gesendet — unabhängig von den Einzeleinstellungen unten.",
+    "settings.row.alertsEnabled.description":
+      "Hauptschalter. Wenn aus, werden keine Benachrichtigungen gesendet — unabhängig von den Einzeleinstellungen unten.",
     "settings.row.alertsNotifyWhileFocused.label": "Auch bei fokussierter App benachrichtigen",
-    "settings.row.alertsNotifyWhileFocused.description": "Zeigt Benachrichtigungen auch, wenn Droppilot das aktive Fenster ist.",
+    "settings.row.alertsNotifyWhileFocused.description":
+      "Zeigt Benachrichtigungen auch, wenn Droppilot das aktive Fenster ist.",
     "settings.row.alertsDropClaimed.label": "Drop eingesammelt",
-    "settings.row.alertsDropClaimed.description": "Ein Drop, auf den du gewartet hast, wurde eingesammelt.",
+    "settings.row.alertsDropClaimed.description":
+      "Ein Drop, auf den du gewartet hast, wurde eingesammelt.",
     "settings.row.alertsDropEndingSoon.label": "Drop endet bald",
-    "settings.row.alertsDropEndingSoon.description": "Ein Drop läuft bald ab. Warnung N Minuten vorher.",
+    "settings.row.alertsDropEndingSoon.description":
+      "Ein Drop läuft bald ab. Warnung N Minuten vorher.",
     "settings.row.alertsDropEndingMinutes.label": "Endet-bald-Schwelle",
-    "settings.row.alertsDropEndingMinutes.description": "Wie viele Minuten vor Ablauf die Warnung kommt.",
+    "settings.row.alertsDropEndingMinutes.description":
+      "Wie viele Minuten vor Ablauf die Warnung kommt.",
     "settings.row.alertsNewDrops.label": "Neue Drops verfügbar",
-    "settings.row.alertsNewDrops.description": "Eine neue Kampagne oder ein neuer Drop ist gerade gedroppt.",
+    "settings.row.alertsNewDrops.description":
+      "Eine neue Kampagne oder ein neuer Drop ist gerade gedroppt.",
     "settings.row.alertsWatchError.label": "Watch-Fehler",
-    "settings.row.alertsWatchError.description": "Der Watcher ist fehlgeschlagen (Auth abgelaufen, Netzwerk, etc.).",
+    "settings.row.alertsWatchError.description":
+      "Der Watcher ist fehlgeschlagen (Auth abgelaufen, Netzwerk, etc.).",
     "settings.row.alertsAutoSwitch.label": "Auto-Switch ausgelöst",
-    "settings.row.alertsAutoSwitch.description": "Die Watch-Engine ist automatisch auf einen anderen Channel gewechselt.",
+    "settings.row.alertsAutoSwitch.description":
+      "Die Watch-Engine ist automatisch auf einen anderen Channel gewechselt.",
     "settings.row.connectionStatus.label": "Verbindungsstatus",
-    "settings.row.connectionStatus.description": "Logout und Re-Login oben rechts in der Titelleiste.",
-    "settings.row.allowUnlinked.description": "Zeigt Drops für Spiele, deren Account du noch nicht mit Twitch verknüpft hast. Diese Drops machen ohne Verknüpfung keinen Fortschritt.",
+    "settings.row.connectionStatus.description":
+      "Abmelden, um das Konto zu wechseln oder die Twitch-Sitzung zu erneuern.",
+    "settings.row.allowUnlinked.description":
+      "Zeigt Drops für Spiele, deren Account du noch nicht mit Twitch verknüpft hast. Diese Drops machen ohne Verknüpfung keinen Fortschritt.",
     "settings.row.debugView.label": "Debug-Ansicht zeigen",
-    "settings.row.debugView.description": "Fügt einen 'debug'-Tab oben hinzu mit Logs, Perf-Snapshots und State-Dump.",
+    "settings.row.debugView.description":
+      "Fügt einen 'debug'-Tab oben hinzu mit Logs, Perf-Snapshots und State-Dump.",
     "settings.row.settingsJson.label": "Settings-JSON",
-    "settings.row.settingsJson.description": "Füge einen JSON-Block ein und klicke Import, oder klicke Export, um deine aktuellen Einstellungen zu kopieren.",
+    "settings.row.settingsJson.description":
+      "Füge einen JSON-Block ein und klicke Import, oder klicke Export, um deine aktuellen Einstellungen zu kopieren.",
 
     "settings.button.sendTest": "test senden",
     "settings.button.reset": "zurücksetzen",
@@ -1669,6 +1719,9 @@ const translations: Translations = {
 
     "settings.account.linked": "verknüpft",
     "settings.account.notLinked": "nicht verknüpft",
+    "settings.account.logout": "Abmelden",
+    "settings.account.login": "Konto verbinden",
+    "settings.account.loggingIn": "Verbinde…",
 
     "control.tracker.label": "tracker",
     "control.tracker.healthy": "Gesund (primär)",
@@ -1791,8 +1844,10 @@ const translations: Translations = {
     "queue.pill.live": "live",
     "queue.pill.queued": "queue",
     "queue.pill.watching": "läuft",
-    "queue.emptyForTarget": "Keine Drops in der Queue für {game} — wähle das nächste Ziel in Prioritäten",
-    "queue.emptyNoTarget": "Kein Ziel-Spiel gesetzt — wähle eins in Prioritäten um seine Queue zu sehen",
+    "queue.emptyForTarget":
+      "Keine Drops in der Queue für {game} — wähle das nächste Ziel in Prioritäten",
+    "queue.emptyNoTarget":
+      "Kein Ziel-Spiel gesetzt — wähle eins in Prioritäten um seine Queue zu sehen",
     "queue.otherGamesHint": "+{count} weitere in anderen Spielen (siehe Inventar)",
 
     // activity.* — Overview activity feed (Phase 18)
@@ -1875,7 +1930,8 @@ const translations: Translations = {
     "control.activeSession.live": "live",
     "control.activeSession.paused": "pausiert",
     "control.activeSession.activeDrop": "aktiver drop",
-    "control.activeSession.watchedRequiredEta": "{watched} geschaut · {required} benötigt · eta {eta}",
+    "control.activeSession.watchedRequiredEta":
+      "{watched} geschaut · {required} benötigt · eta {eta}",
     "control.activeSession.watchedRequired": "{watched} geschaut · {required} benötigt",
     "control.activeSession.noFarmable": "kein farmbarer drop auf diesem channel",
     "control.activeSession.engineIdle": "engine im leerlauf",
@@ -1885,7 +1941,8 @@ const translations: Translations = {
     "control.channelGrid.header": "live channels",
     "control.channelGrid.refreshTitle": "Channel-Liste aktualisieren",
     "control.channelGrid.refresh": "aktualisieren",
-    "control.channelGrid.noTarget": "wähle ein Ziel-Spiel in Prioritäten, um live channels zu sehen",
+    "control.channelGrid.noTarget":
+      "wähle ein Ziel-Spiel in Prioritäten, um live channels zu sehen",
     "control.channelGrid.watchingPill": "watching",
 
     // control.campaignsPanel.* — CampaignsPanel


### PR DESCRIPTION
## Summary
The `user-drop-events` PubSub topic is dead (accepts LISTEN, never delivers), so live drop progress never arrived — ETA stayed static at 30 min and the Queue showed Watched: 0 / Progress: 0%. This PR replaces that dead signal with polling Twitch's `DropCurrentSessionContext` GQL query while watching, and fixes the bug that made the first attempt return null.

- **Phase 19 (b61d7da):** `TwitchService.fetchDropProgress()` polls `DropCurrentSessionContext` every ~45s while watching; the renderer applies the result to inventory state through the same reconciler/dedupe path as PubSub events. Single lightweight GQL call — does **not** increase inventory-refresh frequency (stays under the radar, same cadence the Twitch web player uses).
- **Root-cause fix (25095fe):** the query resolver keys off the watched channel and returns `dropCurrentSession: null` without it. We were sending empty variables `{}`. Now we send `{ channelID: <watched channel id>, channelLogin: "" }` — matching the Twitch web client and TwitchDropsMiner (`constants.py` / `twitch.py`, hash `4d06b702…`). The watched channel id is threaded renderer → IPC → preload → service, via a ref so switching channels doesn't reset the 45s interval.

## Verification
- `tsc -p tsconfig.json` / `tsconfig.node.json`: no new errors in touched files (remaining errors are pre-existing baseline)
- `eslint`: 0 errors (1 pre-existing warning, unrelated)
- `vite build`: green (renderer + main + preload)

## Test plan
- [ ] Start watching a drops-enabled channel
- [ ] DebugView (TwitchService scope) shows `dropProgress: parsed` with non-zero `currentMinutesWatched` (no longer `dropCurrentSession null`)
- [ ] Overview Queue active row + ETA update live within ~45s; Watched/Progress advance
- [ ] Switching channels mid-session keeps progress polling for the new channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)