### PR TITLE
fix(types): resolve 17 pre-existing type errors + gate CI on tsc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Format check
         run: npm run format:check
 
+      - name: Typecheck
+        run: npm run typecheck
+
       - name: Run tests
         run: npm test
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Releases: `npm run release:patch` (also `:minor`, `:major`, and prerelease `:rc`
 ## CI / verification gotchas (important)
 
 - **CI (`.github/workflows/build.yml`) runs only on push to `main` and on `v*` tags — NOT on pull requests.** A PR gets no automated CI; verify locally before merging.
-- CI steps are: lint → `format:check` → `npm test` → `npm run build` → package. **There is no `tsc --noEmit` step.** As a result, some pre-existing type errors exist in the tree (e.g. a `warmupEnabled` error in `useAppModel.ts`) that do not block CI. When you run `tsc`, scope your check to the files you touched (`... | grep <yourfile>`) — don't assume a clean global typecheck.
+- CI steps are: lint → `format:check` → `npm run typecheck` → `npm test` → `npm run build` → package. The typecheck step (`tsc --noEmit`) gates the build, and the tree currently has a clean global typecheck — keep it that way (`npm run typecheck` before pushing to `main`/tags). Note that `npm run build` itself uses esbuild/Vite and does NOT type-check, so `tsc` is the only thing catching type regressions.
 - A clean `format:check` is required — run `prettier --write` on new/changed files before committing or CI fails.
 - `main` is protected (PRs required) but release pushes bypass it. Commit messages follow Conventional Commits (`feat`, `fix`, `docs`, `style`, `refactor`, `chore(release)`).
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "inspect:electron": "node scripts/playwright-inspect-electron.cjs",
     "format": "prettier --write \"src/**/*.{ts,tsx,css}\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx,css}\"",

--- a/src/renderer/shared/domain/inventory/inventoryPubSubPatch.ts
+++ b/src/renderer/shared/domain/inventory/inventoryPubSubPatch.ts
@@ -65,10 +65,13 @@ export const applyPubSubEventToInventoryState = (
     }
   }
 
+  // By this point `items` was non-empty, so `inventory` is either "ready" or
+  // "error" (idle/loading returned early above). Reconstruct per-status so the
+  // result stays a valid InventoryState — a spread of idle/loading + items is not.
   const nextInventory: InventoryState =
-    inventory.status === "ready"
-      ? { status: "ready", items: patch.items }
-      : { ...inventory, items: patch.items };
+    inventory.status === "error"
+      ? { ...inventory, items: patch.items }
+      : { status: "ready", items: patch.items };
 
   return {
     patched: true,

--- a/src/renderer/shared/hooks/app/useDebugSnapshot.ts
+++ b/src/renderer/shared/hooks/app/useDebugSnapshot.ts
@@ -39,6 +39,7 @@ type Params = {
   autoClaim: boolean;
   autoSelectEnabled: boolean;
   autoSwitchEnabled: boolean;
+  warmupEnabled: boolean;
   obeyPriority: boolean;
   allowWatching: boolean;
   refreshMinMs: number;
@@ -74,6 +75,7 @@ export function useDebugSnapshot({
   autoClaim,
   autoSelectEnabled,
   autoSwitchEnabled,
+  warmupEnabled,
   obeyPriority,
   allowWatching,
   refreshMinMs,
@@ -128,6 +130,7 @@ export function useDebugSnapshot({
         autoClaim,
         autoSelectEnabled,
         autoSwitchEnabled,
+        warmupEnabled,
         obeyPriority,
         allowWatching,
         refreshMinMs,
@@ -172,6 +175,7 @@ export function useDebugSnapshot({
       autoClaim,
       autoSelectEnabled,
       autoSwitchEnabled,
+      warmupEnabled,
       channelError,
       channelsCount,
       channelsLoading,

--- a/src/renderer/shared/hooks/inventory/useInventory.ts
+++ b/src/renderer/shared/hooks/inventory/useInventory.ts
@@ -382,7 +382,7 @@ export function useInventory(isLinked: boolean, events?: InventoryEvents, opts?:
         return result.nextInventory;
       });
 
-      const result = patchResult;
+      const result = patchResult as ReturnType<typeof applyPubSubEventToInventoryState> | null;
       if (!result?.patched) return { patched: false };
       totalMinutesRef.current = result.nextTotalMinutes ?? totalMinutesRef.current ?? 0;
       if (result.deltaMinutes > 0) {
@@ -397,7 +397,8 @@ export function useInventory(isLinked: boolean, events?: InventoryEvents, opts?:
         setProgressAnchorByDropId((prev) => mergeProgressAnchors(prev, anchorIds, eventAt));
       }
       if (result.updatedId) {
-        setInventoryChanges((prev) => markUpdatedInventoryChange(prev, result.updatedId));
+        const updatedId = result.updatedId;
+        setInventoryChanges((prev) => markUpdatedInventoryChange(prev, updatedId));
       }
       return {
         patched: true,
@@ -492,7 +493,7 @@ export function useInventory(isLinked: boolean, events?: InventoryEvents, opts?:
     if (inventory.status === "ready") return inventory.items;
     if (inventory.status === "error" && inventory.items) return inventory.items;
     return [];
-  }, [inventory.items, inventory.status]);
+  }, [inventory]);
 
   const uniqueGames = useMemo(
     () => Array.from(new Set(inventoryItems.map((i) => i.game))).sort(),

--- a/src/renderer/shared/hooks/watch/useChannels.ts
+++ b/src/renderer/shared/hooks/watch/useChannels.ts
@@ -932,6 +932,9 @@ export function useChannels({
       clearWatching();
       return;
     }
+    // computeAutoSwitchAction only returns a "switch" when `watching` is set,
+    // so this never returns at runtime — it just makes the invariant explicit.
+    if (!watching) return;
     setWatchingFromChannel(action.nextChannel);
     setAutoSwitch({
       at: Date.now(),

--- a/src/renderer/shared/utils/ipc.ts
+++ b/src/renderer/shared/utils/ipc.ts
@@ -2,6 +2,7 @@ import type {
   ChannelEntry,
   ChannelLiveDiff,
   ChannelTrackerStatus,
+  CampaignDropSummary,
   CampaignSummary,
   InventoryItem,
   PriorityPlan,
@@ -240,7 +241,7 @@ export const isInventoryItem = (value: unknown): value is InventoryItem => {
 const isInventoryStatus = (value: unknown): value is InventoryItem["status"] =>
   value === "locked" || value === "progress" || value === "claimed";
 
-const isCampaignDropSummary = (value: unknown): boolean => {
+const isCampaignDropSummary = (value: unknown): value is CampaignDropSummary => {
   if (!isRecord(value)) return false;
   return (
     isString(value.id) &&


### PR DESCRIPTION
@
## Warum
Der Tree hatte **17 Typfehler**, die nie CI blockiert haben, weil es keinen `tsc --noEmit`-Step gibt (CLAUDE.md dokumentierte nur einen davon — `warmupEnabled`). Dieser PR fixt alle an der Wurzel und fügt einen CI-Gate hinzu, damit sie nicht zurückkommen.

## Fixes (Root-Cause, keine `any`-Hacks)
| Datei | Problem | Fix |
|---|---|---|
| `inventoryPubSubPatch.ts` | Spread von `idle`/`loading` + `items` ergibt kein gültiges `InventoryState` | `nextInventory` per-Status bauen (an der Stelle ist `inventory` beweisbar `ready`/`error`) |
| `useInventory.ts` | Closure-captured Patch-Result → `never`-Kaskade (12×) | captured Result typisieren (gleicher `as ReturnType<…>`-Idiom wie 200 Zeilen weiter unten); `updatedId` vor dem setState-Closure capturen; Dep `[inventory]` statt `[inventory.items]` |
| `useChannels.ts` | `watching` possibly null | expliziter `if (!watching) return` — `computeAutoSwitchAction` liefert "switch" nur bei gesetztem `watching`, daher runtime-neutral |
| `ipc.ts` | `isCampaignDropSummary` ist kein Type-Predicate | `value is CampaignDropSummary` (Body validiert die Typ-Shape vollständig) |
| `useDebugSnapshot.ts` | `warmupEnabled` übergeben aber nicht im Params-Typ | in den `automation`-Block aufgenommen (steht am Call-Site bei den Geschwister-Toggles) |

## CI-Gate
- Neues `typecheck`-Script (`tsc --noEmit -p tsconfig.json`)
- Neuer **Typecheck**-Step in `build.yml` (nach `format:check`, vor Tests) → `tsc` gated jetzt Pushes auf `main` / `v*`-Tags

## Verifikation
`npm run typecheck` (clean ✓), `npm test` (288 ✓), `npm run build` ✓, `npm run lint` ✓, `npm run format:check` ✓.

> ℹ️ **Unabhängig** von #47/#48 (off `main`). Die Fixes sind config-/TS-versionsunabhängige Typ-Logik — verifiziert, dass dieselben 17 Fehler unter TS 5.9+Node, TS 5.9+bundler und TS 6+bundler identisch auftraten. Bei beliebiger Merge-Reihenfolge mit #47 (TS 6) bleibt `tsc` grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@