### PR TITLE
fix(ci): pin .mjs/.cjs to eol=lf — unbreak Windows format:check

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,6 +9,8 @@
 *.tsx text eol=lf
 *.js text eol=lf
 *.jsx text eol=lf
+*.mjs text eol=lf
+*.cjs text eol=lf
 *.json text eol=lf
 *.css text eol=lf
 *.html text eol=lf


### PR DESCRIPTION
## Root cause (confirmed, not guessed)

The post-merge `build` on **windows-latest** failed at `Format check` (`prettier --check`); macOS build and the ubuntu PR `verify` were green, and the `release` job was skipped only because it `needs: build`.

`.gitattributes` pins every known text type to `eol=lf` (`*.ts`, `*.tsx`, `*.js`, `*.css`, …) but had **no rule for `*.mjs`** — the extension #57 introduced. The new release-notes scripts therefore fell under the `* text=auto` catch-all, which checks them out **CRLF on Windows**. `git ls-files --eol` shows it exactly:

```
i/lf  w/crlf  attr/text=auto     scripts/release-notes/lib/finalize.mjs   ← the .mjs files
i/lf  w/lf    attr/text eol=lf   src/main/index.ts                        ← everything else
```

Prettier's default `endOfLine: "lf"` then flagged all 13 `.mjs` files (and zero `src` files) **only on the Windows runner**. Linux/macOS check `text=auto` out as LF and passed.

## Fix

Pin `*.mjs` (and its sibling `*.cjs`) to `eol=lf` next to `*.js`, matching the file's existing pattern. The repo blobs were already LF (`i/lf`); this only corrects the Windows working-tree checkout. One-line-class change, no code touched.

## Verification

Reproduced and fixed on a **local Windows machine — the same OS that failed in CI** (the ubuntu `verify` job below cannot exercise this, since Linux checks out LF regardless):

- Before: `npm run format:check` → fails on the 13 `.mjs` files (matches the CI log byte-for-byte).
- After: `git ls-files --eol` shows `w/lf attr/text eol=lf`; `format:check` clean; full gate green (typecheck both configs, lint 0 errors, **475 tests**, build).

The real proof is the post-merge Windows `build` job — expected green, unblocking the `release` job (which runs on ubuntu and was never the problem).

🤖 Generated with [Claude Code](https://claude.com/claude-code)