### PR TITLE
feat(planner): Smart Drops Planner — advisory EDF plan-queue

### DIFF
--- a/docs/superpowers/plans/2026-06-13-smart-drops-planner-priority-aware.md
+++ b/docs/superpowers/plans/2026-06-13-smart-drops-planner-priority-aware.md
@@ -1,0 +1,592 @@
+# Smart Drops Planner — Priority-Aware Ordering Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Smart Drops Planner mirror the watch engine's actual farming order (priority order; strict = priority games only; permissive = priority then fallback) and turn deadlines into a per-game feasibility/risk warning, instead of sorting everything by pure EDF.
+
+**Architecture:** Extend the pure `buildDropsPlan` with an optional `{ priorityGames, obeyPriority }` options arg that drives game ordering; the per-drop feasibility walk then runs along that engine order. The card receives `priorityGames`/`obeyPriority` as props threaded from `useAppModel` → `OverviewView` (NOT by re-calling `useSettingsStore`, which is a per-call `useState` hook with no shared store). Adds a priority-rank cell and a fallback divider.
+
+**Tech Stack:** TypeScript, React 19, Vitest (pure-function tests only), Tailwind v4 `--dp-*` tokens.
+
+**Spec:** `docs/superpowers/specs/2026-06-13-smart-drops-planner-priority-aware-design.md` (addendum to `…-smart-drops-planner-design.md`).
+
+---
+
+## File structure
+
+| File | Change |
+| --- | --- |
+| `src/renderer/shared/domain/dropsPlanner.ts` | **modify** — add `DropsPlanOptions`, priority partition/order, `isPriority`/`priorityRank` |
+| `src/renderer/shared/domain/dropsPlanner.test.ts` | **modify** — append priority-aware tests (existing 11 must stay green) |
+| `src/renderer/shared/i18n.tsx` | **modify** — add `plan.fallbackDivider` (EN + DE) |
+| `src/renderer/features/overview/DropsPlanCard.tsx` | **modify** — optional `priorityGames`/`obeyPriority` props, priority rank cell, fallback divider |
+| `src/renderer/features/overview/OverviewView.tsx` | **modify** — add the two fields to `OverviewProps`, pass to `DropsPlanCard` |
+| `src/renderer/shared/hooks/app/useAppModel.ts` | **modify** — add `priorityGames`/`obeyPriority` to `overviewProps` |
+
+**Task ordering note:** Task 3 makes the card props **optional** (default `[]`/`false`), so the existing `<DropsPlanCard items={items} />` in `OverviewView` still typechecks after Task 3. Task 4 then threads the real values. Each task ends typecheck-green.
+
+---
+
+## Task 1: Priority-aware planner (`dropsPlanner.ts`)
+
+**Files:**
+- Modify: `src/renderer/shared/domain/dropsPlanner.ts`
+- Test: `src/renderer/shared/domain/dropsPlanner.test.ts`
+
+- [ ] **Step 1: Append the failing tests**
+
+Append this new `describe` block to the END of `src/renderer/shared/domain/dropsPlanner.test.ts` (it reuses the existing `makeItem`, `iso`, `NOW` helpers already defined at the top of the file). Do NOT modify the existing tests.
+
+```ts
+describe("buildDropsPlan — priority-aware", () => {
+  it("strict mode shows only priority games, in priority order", () => {
+    const plan = buildDropsPlan(
+      [
+        makeItem({ id: "a", game: "Apex", endsAt: iso(60) }),
+        makeItem({ id: "b", game: "Brawl", endsAt: iso(30) }),
+        makeItem({ id: "c", game: "Cult", endsAt: iso(10) }),
+      ],
+      NOW,
+      { priorityGames: ["Brawl", "Apex"], obeyPriority: true },
+    );
+    expect(plan.map((e) => e.gameLabel)).toEqual(["Brawl", "Apex"]);
+    // Non-priority "Cult" excluded even though its deadline is soonest.
+    expect(plan.some((e) => e.gameLabel === "Cult")).toBe(false);
+  });
+
+  it("permissive mode lists priority games first, then fallback by EDF", () => {
+    const plan = buildDropsPlan(
+      [
+        makeItem({ id: "p1", game: "P1", endsAt: iso(600) }),
+        makeItem({ id: "f-late", game: "FLate", endsAt: iso(300) }),
+        makeItem({ id: "f-soon", game: "FSoon", endsAt: iso(120) }),
+      ],
+      NOW,
+      { priorityGames: ["P1"], obeyPriority: false },
+    );
+    expect(plan.map((e) => e.gameLabel)).toEqual(["P1", "FSoon", "FLate"]);
+    expect(plan.map((e) => e.isPriority)).toEqual([true, false, false]);
+  });
+
+  it("assigns 1-based priorityRank matched case-insensitively", () => {
+    const plan = buildDropsPlan([makeItem({ game: "Rust" })], NOW, {
+      priorityGames: ["rust"],
+      obeyPriority: false,
+    });
+    expect(plan[0].isPriority).toBe(true);
+    expect(plan[0].priorityRank).toBe(1);
+  });
+
+  it("computes feasibility along priority order (deadline risk), not EDF", () => {
+    const items = [
+      makeItem({ id: "a", game: "A", requiredMinutes: 180, endsAt: iso(10000) }),
+      makeItem({ id: "b", game: "B", requiredMinutes: 60, endsAt: iso(90) }),
+    ];
+    // Priority order [A, B]: A consumes 180min, so B completes at 240min > 90min → lost.
+    const strict = buildDropsPlan(items, NOW, { priorityGames: ["A", "B"], obeyPriority: true });
+    expect(strict.find((e) => e.gameLabel === "B")?.status).toBe("lost");
+    // Pure EDF (no options) would farm B first → B feasible.
+    const edf = buildDropsPlan(items, NOW);
+    expect(edf.find((e) => e.gameLabel === "B")?.status).toBe("ok");
+  });
+
+  it("empty priority list + permissive equals the pure-EDF (no-options) result", () => {
+    const items = [
+      makeItem({ id: "x", game: "X", endsAt: iso(120) }),
+      makeItem({ id: "y", game: "Y", endsAt: iso(60) }),
+    ];
+    expect(buildDropsPlan(items, NOW, { priorityGames: [], obeyPriority: false })).toEqual(
+      buildDropsPlan(items, NOW),
+    );
+  });
+
+  it("empty priority list + strict yields an empty plan", () => {
+    const plan = buildDropsPlan([makeItem({ game: "X", endsAt: iso(60) })], NOW, {
+      priorityGames: [],
+      obeyPriority: true,
+    });
+    expect(plan).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify the new ones fail**
+
+Run: `npx vitest run src/renderer/shared/domain/dropsPlanner.test.ts`
+Expected: the 11 existing tests still PASS; the 6 new ones FAIL (e.g. `buildDropsPlan` ignores the 3rd arg, `isPriority`/`priorityRank` undefined).
+
+- [ ] **Step 3: Rewrite `dropsPlanner.ts` with the options-driven ordering**
+
+Overwrite `src/renderer/shared/domain/dropsPlanner.ts` with this exact content:
+
+```ts
+import type { InventoryItem } from "@renderer/shared/types";
+import { canEarnDrop } from "./inventory/inventoryRules";
+import { InventoryDrop } from "./dropDomain";
+import { normalizeGameName } from "./gameName";
+
+const MINUTE_MS = 60_000;
+
+export type PlanDrop = {
+  id: string;
+  title: string;
+  requiredMinutes: number;
+  earnedMinutes: number;
+  remainingMinutes: number;
+  deadlineMs: number | null;
+  feasible: boolean;
+};
+
+export type PlanEntry = {
+  gameKey: string;
+  gameLabel: string;
+  watchMinutes: number;
+  deadlineMs: number | null; // earliest tier deadline — countdown; per-drop feasibility uses each drop's own deadlineMs
+  status: "ok" | "partial" | "lost";
+  feasibleDropCount: number;
+  totalDropCount: number;
+  isPriority: boolean; // game is on the priority list
+  priorityRank: number | null; // 1-based priority position; null for fallback games
+  drops: PlanDrop[];
+};
+
+export type DropsPlanOptions = {
+  priorityGames: string[];
+  obeyPriority: boolean;
+};
+
+const DEFAULT_OPTIONS: DropsPlanOptions = { priorityGames: [], obeyPriority: false };
+
+/** ISO → ms with a finite guard (mirrors InventoryDrop.isExpired parsing). */
+function parseFiniteMs(value: string | undefined): number | null {
+  if (!value) return null;
+  const ms = Date.parse(value);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+/** A drop is plannable if it can still be earned and is not excluded/expired/future. */
+export function isPlannableDrop(item: InventoryItem, now: number): boolean {
+  if (!canEarnDrop(item, { allowUpcoming: true })) return false;
+  if (item.excluded === true) return false;
+  if (new InventoryDrop(item).isExpired(now)) return false;
+  const startsAtMs = parseFiniteMs(item.startsAt);
+  if (startsAtMs !== null && startsAtMs > now) return false;
+  return true;
+}
+
+type Shell = {
+  gameKey: string;
+  gameLabel: string;
+  deadlineMs: number | null;
+  drops: Omit<PlanDrop, "feasible">[];
+};
+
+export function buildDropsPlan(
+  items: InventoryItem[],
+  now: number,
+  options: DropsPlanOptions = DEFAULT_OPTIONS,
+): PlanEntry[] {
+  // 1. Filter to plannable drops.
+  const plannable = items.filter((it) => isPlannableDrop(it, now));
+
+  // 2. Group by normalized game name (keep first-seen original casing for display).
+  const groups = new Map<string, { label: string; items: InventoryItem[] }>();
+  for (const it of plannable) {
+    const key = normalizeGameName(it.game);
+    const group = groups.get(key);
+    if (group) group.items.push(it);
+    else groups.set(key, { label: it.game, items: [it] });
+  }
+
+  // 3. Build per-game shells: drops (sorted by remaining asc) + earliest deadline.
+  const shells: Shell[] = [];
+  for (const [key, { label, items: groupItems }] of groups) {
+    const drops = groupItems
+      .map((it) => {
+        const drop = new InventoryDrop(it);
+        return {
+          id: drop.id,
+          title: drop.title,
+          requiredMinutes: drop.requiredMinutes,
+          earnedMinutes: drop.earnedMinutes,
+          remainingMinutes: drop.remainingMinutes,
+          deadlineMs: parseFiniteMs(it.endsAt),
+        };
+      })
+      .sort((a, b) => a.remainingMinutes - b.remainingMinutes);
+    const deadlines = drops.map((d) => d.deadlineMs).filter((v): v is number => v !== null);
+    const deadlineMs = deadlines.length ? Math.min(...deadlines) : null;
+    shells.push({ gameKey: key, gameLabel: label, deadlineMs, drops });
+  }
+
+  // 4. Order by the engine's actual farming order, not pure deadline.
+  //    priorityRankByKey: normalized priority game → 1-based rank (lowest index wins).
+  const priorityRankByKey = new Map<string, number>();
+  options.priorityGames.forEach((game, idx) => {
+    const key = normalizeGameName(game);
+    if (key && !priorityRankByKey.has(key)) priorityRankByKey.set(key, idx + 1);
+  });
+
+  // EDF comparator — used for the fallback tail and the no-priority case.
+  const byEdf = (a: Shell, b: Shell) => {
+    const da = a.deadlineMs ?? Number.POSITIVE_INFINITY;
+    const db = b.deadlineMs ?? Number.POSITIVE_INFINITY;
+    if (da !== db) return da - db;
+    const wa = Math.max(0, ...a.drops.map((d) => d.remainingMinutes));
+    const wb = Math.max(0, ...b.drops.map((d) => d.remainingMinutes));
+    if (wa !== wb) return wa - wb;
+    return a.gameKey < b.gameKey ? -1 : a.gameKey > b.gameKey ? 1 : 0;
+  };
+
+  const priorityShells = shells
+    .filter((s) => priorityRankByKey.has(s.gameKey))
+    .sort((a, b) => priorityRankByKey.get(a.gameKey)! - priorityRankByKey.get(b.gameKey)!);
+  const fallbackShells = shells.filter((s) => !priorityRankByKey.has(s.gameKey)).sort(byEdf);
+
+  // Strict: only priority games. Permissive: priority games, then fallback (EDF).
+  const orderedShells = options.obeyPriority
+    ? priorityShells
+    : [...priorityShells, ...fallbackShells];
+
+  // 5. Feasibility walk along the engine order: a watch-minute cursor accumulates.
+  const result: PlanEntry[] = [];
+  let cursor = 0;
+  for (const shell of orderedShells) {
+    const cursorStart = cursor;
+    const drops: PlanDrop[] = shell.drops.map((d) => {
+      const completionMs = now + (cursorStart + d.remainingMinutes) * MINUTE_MS;
+      const feasible = d.deadlineMs === null || completionMs <= d.deadlineMs;
+      return { ...d, feasible };
+    });
+    const feasibleDrops = drops.filter((d) => d.feasible);
+    // Minutes actually spent here: max remaining among feasible drops only
+    // (a partial game's lost tiers are excluded; a fully-lost game → 0).
+    const watchMinutes = feasibleDrops.length
+      ? Math.max(...feasibleDrops.map((d) => d.remainingMinutes))
+      : 0;
+    const status: PlanEntry["status"] =
+      feasibleDrops.length === drops.length ? "ok" : feasibleDrops.length > 0 ? "partial" : "lost";
+    const priorityRank = priorityRankByKey.get(shell.gameKey) ?? null;
+    cursor = cursorStart + watchMinutes;
+    result.push({
+      gameKey: shell.gameKey,
+      gameLabel: shell.gameLabel,
+      watchMinutes,
+      deadlineMs: shell.deadlineMs,
+      status,
+      feasibleDropCount: feasibleDrops.length,
+      totalDropCount: drops.length,
+      isPriority: priorityRank !== null,
+      priorityRank,
+      drops,
+    });
+  }
+  return result;
+}
+```
+
+- [ ] **Step 4: Run the tests to verify all pass**
+
+Run: `npx vitest run src/renderer/shared/domain/dropsPlanner.test.ts`
+Expected: PASS — 17 tests (11 existing + 6 new). If any fail, debug the root cause; do not weaken tests.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `npm run typecheck`
+Expected: exit 0 on both tsconfigs.
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+npx prettier --write src/renderer/shared/domain/dropsPlanner.ts src/renderer/shared/domain/dropsPlanner.test.ts
+git add src/renderer/shared/domain/dropsPlanner.ts src/renderer/shared/domain/dropsPlanner.test.ts
+git commit -m "feat(planner): priority-aware engine-order plan + per-order feasibility"
+```
+
+---
+
+## Task 2: i18n `plan.fallbackDivider`
+
+**Files:**
+- Modify: `src/renderer/shared/i18n.tsx`
+
+- [ ] **Step 1: Add the key to the ENGLISH block**
+
+Find the English `"plan.lost":` entry (search for `"plan.lost":` — the FIRST occurrence is the EN block) and add this line immediately after it:
+
+```ts
+    "plan.fallbackDivider": "then (fallback)",
+```
+
+- [ ] **Step 2: Add the key to the GERMAN block**
+
+Find the German `"plan.lost":` entry (the SECOND occurrence of `"plan.lost":`) and add this line immediately after it:
+
+```ts
+    "plan.fallbackDivider": "danach (Fallback)",
+```
+
+- [ ] **Step 3: Typecheck + confirm DE parity**
+
+Run: `npm run typecheck`
+Expected: exit 0. Note: the `t()` key type derives from the EN block, so a missing DE key is NOT a type error — manually confirm `"plan.fallbackDivider"` appears exactly twice in the file (once EN, once DE).
+
+- [ ] **Step 4: Format and commit**
+
+```bash
+npx prettier --write src/renderer/shared/i18n.tsx
+git add src/renderer/shared/i18n.tsx
+git commit -m "feat(planner): add plan.fallbackDivider i18n key (EN + DE)"
+```
+
+---
+
+## Task 3: Card — priority rank + fallback divider
+
+**Files:**
+- Modify: `src/renderer/features/overview/DropsPlanCard.tsx`
+
+The props `priorityGames`/`obeyPriority` are **optional** here so the existing `<DropsPlanCard items={items} />` in `OverviewView` keeps typechecking until Task 4 threads the real values.
+
+- [ ] **Step 1: Overwrite `DropsPlanCard.tsx`**
+
+Overwrite `src/renderer/features/overview/DropsPlanCard.tsx` with this exact content:
+
+```tsx
+import * as React from "react";
+import { Card, CardHeader, CardTitle, CardContent } from "@renderer/shared/components/ui/card";
+import { Pill } from "@renderer/shared/components/ui/pill";
+import type { InventoryItem } from "@renderer/shared/types";
+import { useI18n } from "@renderer/shared/i18n";
+import { useVisibleTick } from "@renderer/shared/hooks/useVisibleTick";
+import { cn } from "@renderer/shared/lib/utils";
+import { buildDropsPlan, type PlanEntry } from "@renderer/shared/domain/dropsPlanner";
+import { formatRemaining } from "@renderer/shared/utils";
+
+const URGENT_MS = 2 * 60 * 60 * 1000;
+type TFn = ReturnType<typeof useI18n>["t"];
+
+export type DropsPlanCardProps = {
+  items: InventoryItem[];
+  priorityGames?: string[];
+  obeyPriority?: boolean;
+};
+
+export function DropsPlanCard({ items, priorityGames = [], obeyPriority = false }: DropsPlanCardProps) {
+  const { t } = useI18n();
+  // Owns its own 60s tick (paused while the window is hidden) so feasibility/
+  // countdowns refresh without any useAppModel plumbing.
+  const now = useVisibleTick(60_000);
+  const plan = React.useMemo(
+    () => buildDropsPlan(items, now, { priorityGames, obeyPriority }),
+    [items, now, priorityGames, obeyPriority],
+  );
+  const feasibleCount = plan.filter((e) => e.status === "ok").length;
+  // Boundary between priority games and the permissive fallback tail.
+  const firstFallbackIdx = plan.findIndex((e) => !e.isPriority);
+
+  return (
+    <Card className="bg-[color:var(--dp-bg-elevated)] border-[color:var(--dp-border)] rounded-[var(--dp-radius-lg)]">
+      <CardHeader className="flex flex-row items-center justify-between border-b border-[color:var(--dp-border-soft)] py-3.5">
+        <CardTitle className="font-mono text-[11px] uppercase tracking-[0.14em] text-[color:var(--dp-text-dim)] font-normal">
+          {t("plan.title")}
+        </CardTitle>
+        {plan.length > 0 && (
+          <span className="font-mono text-[10px] text-[color:var(--dp-text-dimmer)]">
+            {t("plan.feasibleCount", { count: feasibleCount, total: plan.length })}
+          </span>
+        )}
+      </CardHeader>
+      <CardContent className="p-0">
+        {plan.length === 0 ? (
+          <div className="px-5 py-8 text-center font-mono text-[11px] text-[color:var(--dp-text-dimmer)]">
+            {t("plan.empty")}
+          </div>
+        ) : (
+          <ul className="divide-y divide-[color:var(--dp-border-soft)]">
+            {plan.map((entry, idx) => (
+              <React.Fragment key={entry.gameKey}>
+                {idx === firstFallbackIdx && firstFallbackIdx > 0 && (
+                  <li className="px-5 py-1.5 text-center font-mono text-[10px] uppercase tracking-[0.12em] text-[color:var(--dp-text-dimmer)]">
+                    — {t("plan.fallbackDivider")} —
+                  </li>
+                )}
+                <PlanRow entry={entry} now={now} t={t} />
+              </React.Fragment>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function PlanRow({ entry, now, t }: { entry: PlanEntry; now: number; t: TFn }) {
+  // Representative = the longest open drop (drops are sorted by remaining asc).
+  const rep = entry.drops[entry.drops.length - 1];
+  const pct =
+    rep.requiredMinutes > 0
+      ? Math.max(0, Math.min(100, Math.round((rep.earnedMinutes / rep.requiredMinutes) * 100)))
+      : 0;
+  const lost = entry.status === "lost";
+  const urgent = !lost && entry.deadlineMs !== null && entry.deadlineMs - now < URGENT_MS;
+  const countdown =
+    entry.deadlineMs !== null
+      ? t("plan.endsIn", {
+          time: formatRemaining(Math.max(0, Math.round((entry.deadlineMs - now) / 1000))),
+        })
+      : null;
+
+  return (
+    <li
+      className={cn(
+        "flex items-center gap-3 px-5 py-3",
+        lost && "opacity-50",
+        urgent && "border-l-2 border-l-[color:var(--dp-signal-err)]",
+      )}
+    >
+      <span className="font-mono text-[11px] tabular-nums text-[color:var(--dp-text-dimmer)]">
+        {entry.priorityRank !== null ? `#${entry.priorityRank}` : "·"}
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className={cn("truncate text-[13px] text-[color:var(--dp-text)]", lost && "line-through")}>
+          {entry.gameLabel}
+          <span className="text-[color:var(--dp-text-dimmer)]"> · {rep.title}</span>
+        </div>
+        <div
+          role="progressbar"
+          aria-valuenow={pct}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label={entry.gameLabel}
+          className="mt-1 h-[5px] w-full overflow-hidden rounded-full bg-[color:var(--dp-border)]"
+        >
+          <div className="h-full bg-[color:var(--dp-signal-ok)]" style={{ width: `${pct}%` }} />
+        </div>
+      </div>
+      <div className="flex flex-col items-end gap-1">
+        {entry.status === "lost" ? (
+          <Pill tone="err">
+            <span aria-hidden="true">⚠</span> {t("plan.lost")}
+          </Pill>
+        ) : entry.status === "partial" ? (
+          <Pill tone="warn">
+            <span aria-hidden="true">⚠</span>{" "}
+            {t("plan.atRisk", {
+              count: entry.totalDropCount - entry.feasibleDropCount,
+              total: entry.totalDropCount,
+            })}
+          </Pill>
+        ) : (
+          <Pill tone="ok">
+            {/* watchMinutes is in minutes; *60 → seconds for formatRemaining */}
+            <span aria-hidden="true">⏳</span>{" "}
+            {t("plan.remaining", { time: formatRemaining(entry.watchMinutes * 60) })}
+          </Pill>
+        )}
+        {countdown && (
+          <span
+            className={cn(
+              "font-mono text-[10px]",
+              urgent ? "text-[color:var(--dp-signal-err)]" : "text-[color:var(--dp-text-dimmer)]",
+            )}
+          >
+            {countdown}
+          </span>
+        )}
+      </div>
+    </li>
+  );
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npm run typecheck`
+Expected: exit 0. (The optional props mean `OverviewView`'s existing `<DropsPlanCard items={items} />` still compiles.)
+
+- [ ] **Step 3: Format and commit**
+
+```bash
+npx prettier --write src/renderer/features/overview/DropsPlanCard.tsx
+git add src/renderer/features/overview/DropsPlanCard.tsx
+git commit -m "feat(planner): priority rank cell + fallback divider in DropsPlanCard"
+```
+
+---
+
+## Task 4: Thread priority props + full verification
+
+**Files:**
+- Modify: `src/renderer/shared/hooks/app/useAppModel.ts`
+- Modify: `src/renderer/features/overview/OverviewView.tsx`
+
+- [ ] **Step 1: Expose the two fields on `overviewProps` (`useAppModel.ts`)**
+
+In `src/renderer/shared/hooks/app/useAppModel.ts`, find the `const overviewProps = { … }` object literal (it starts with `inventory,` and ends with `watchError: watchStats.lastError,`). Add these two lines inside that object (anywhere in it, e.g. right after `inventory,`):
+
+```ts
+    priorityGames,
+    obeyPriority,
+```
+
+`priorityGames` and `obeyPriority` are already in scope in `useAppModel` (destructured from its existing `useSettingsStore()` call). If typecheck reports they are NOT in scope, add them to that existing settings destructuring rather than calling the hook again.
+
+- [ ] **Step 2: Add the props to `OverviewProps` and pass them down (`OverviewView.tsx`)**
+
+In `src/renderer/features/overview/OverviewView.tsx`:
+
+(a) Add two fields to the `OverviewProps` type (next to the other primitives, e.g. after `activeGame: string;`):
+
+```ts
+  priorityGames: string[];
+  obeyPriority: boolean;
+```
+
+(b) Add `priorityGames` and `obeyPriority` to the destructured props in the component's parameter list (the `{ … }: OverviewProps` destructuring).
+
+(c) Change the planner mount from:
+
+```tsx
+        <DropsPlanCard items={items} />
+```
+
+to:
+
+```tsx
+        <DropsPlanCard items={items} priorityGames={priorityGames} obeyPriority={obeyPriority} />
+```
+
+- [ ] **Step 3: Typecheck (both configs)**
+
+Run: `npm run typecheck`
+Expected: exit 0. (Confirms `overviewProps` now satisfies the extended `OverviewProps`, and the card receives the props.)
+
+- [ ] **Step 4: Run the full test suite**
+
+Run: `npm test`
+Expected: PASS — all tests including the 17 `dropsPlanner` tests. Report the total count.
+
+- [ ] **Step 5: Format-check and build**
+
+Run: `npm run format:check`
+Expected: clean. If not, run `npm run format` and re-commit.
+
+Run: `npm run build`
+Expected: renderer + main/preload build with no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/renderer/shared/hooks/app/useAppModel.ts src/renderer/features/overview/OverviewView.tsx
+git commit -m "feat(planner): thread priorityGames/obeyPriority to DropsPlanCard"
+```
+
+---
+
+## Self-review notes (reconciled with the spec)
+
+- **Spec coverage:** ordering model (strict / permissive / empty-priority) → Task 1 `buildDropsPlan` + tests; `isPriority`/`priorityRank` → Task 1; engine-order feasibility risk → Task 1 "feasibility along priority order" test; priority rank cell + fallback divider → Task 3; `plan.fallbackDivider` EN+DE → Task 2; prop threading (NOT re-reading `useSettingsStore`) → Task 4.
+- **Type consistency:** `DropsPlanOptions { priorityGames; obeyPriority }` and `PlanEntry.isPriority`/`priorityRank` are identical across planner, tests, and card. Card props `priorityGames?`/`obeyPriority?` are optional; `OverviewProps` declares them required and `useAppModel` always supplies them.
+- **Backward-compat:** `buildDropsPlan(items, now)` with no options → `DEFAULT_OPTIONS` (empty priority, permissive) → pure EDF, so the existing 11 tests pass unchanged (verified by the "empty priority + permissive equals no-options" test).
+- **No watch-engine / IPC / orchestration / AppContent changes.**

--- a/docs/superpowers/plans/2026-06-13-smart-drops-planner.md
+++ b/docs/superpowers/plans/2026-06-13-smart-drops-planner.md
@@ -1,0 +1,594 @@
+# Smart Drops Planner Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an advisory, deadline-ordered "Plan-Queue" card to the Overview that tells the user which games to watch and in what order, with a per-drop feasibility flag.
+
+**Architecture:** A pure function `buildDropsPlan(items, now)` (in `shared/domain/`) computes an Earliest-Deadline-First plan grouped by game, with feasibility evaluated **per drop** (drops of a game progress in parallel against their own deadlines). A thin `DropsPlanCard` renders it, sourcing a 60s `now` tick from the existing `useVisibleTick`. No changes to the watch engine, IPC, or `useAppModel`.
+
+**Tech Stack:** TypeScript, React 19, Vitest (pure-function tests only — no `@testing-library/react`), Tailwind v4 with `--dp-*` design tokens.
+
+**Spec:** `docs/superpowers/specs/2026-06-13-smart-drops-planner-design.md`
+
+---
+
+## File structure
+
+| File | Responsibility |
+| --- | --- |
+| `src/renderer/shared/domain/dropsPlanner.ts` | **new** — `PlanDrop` / `PlanEntry` types, `isPlannableDrop`, `buildDropsPlan` (all pure) |
+| `src/renderer/shared/domain/dropsPlanner.test.ts` | **new** — unit tests for the planner |
+| `src/renderer/features/overview/DropsPlanCard.tsx` | **new** — the Plan-Queue card (thin React wrapper) |
+| `src/renderer/features/overview/OverviewView.tsx` | **modify** — mount `<DropsPlanCard items={items} />` |
+| `src/renderer/shared/i18n.tsx` | **modify** — add `plan.*` keys to the EN and DE blocks |
+
+---
+
+## Task 1: Pure planner (`dropsPlanner.ts`)
+
+**Files:**
+- Create: `src/renderer/shared/domain/dropsPlanner.ts`
+- Test: `src/renderer/shared/domain/dropsPlanner.test.ts`
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `src/renderer/shared/domain/dropsPlanner.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import type { InventoryItem } from "@renderer/shared/types";
+import { buildDropsPlan } from "./dropsPlanner";
+
+const NOW = 1_700_000_000_000;
+const MIN = 60_000;
+const iso = (offsetMinutes: number) => new Date(NOW + offsetMinutes * MIN).toISOString();
+
+const makeItem = (o: Partial<InventoryItem> = {}): InventoryItem => ({
+  id: "d1",
+  game: "Rust",
+  title: "Drop",
+  requiredMinutes: 60,
+  earnedMinutes: 0,
+  status: "progress",
+  ...o,
+});
+
+describe("buildDropsPlan", () => {
+  it("returns [] for empty input", () => {
+    expect(buildDropsPlan([], NOW)).toEqual([]);
+  });
+
+  it("groups differently-cased game names into one entry", () => {
+    const plan = buildDropsPlan(
+      [
+        makeItem({ id: "a", game: "Marvel Rivals" }),
+        makeItem({ id: "b", game: "marvel rivals " }),
+      ],
+      NOW,
+    );
+    expect(plan).toHaveLength(1);
+    expect(plan[0].totalDropCount).toBe(2);
+  });
+
+  it("treats parallel tiers as feasible against their own deadlines (regression)", () => {
+    // Short low tier (40min deadline) + long high tier (far deadline), same game.
+    // The old min-deadline/max-remaining model wrongly flagged this 'lost'.
+    const plan = buildDropsPlan(
+      [
+        makeItem({ id: "low", requiredMinutes: 30, endsAt: iso(40) }),
+        makeItem({ id: "high", requiredMinutes: 120, endsAt: iso(60 * 24 * 9) }),
+      ],
+      NOW,
+    );
+    expect(plan).toHaveLength(1);
+    expect(plan[0].status).toBe("ok");
+    expect(plan[0].feasibleDropCount).toBe(2);
+  });
+
+  it("marks a game partial when one tier can't make its deadline", () => {
+    const plan = buildDropsPlan(
+      [
+        makeItem({ id: "doomed", requiredMinutes: 30, endsAt: iso(10) }),
+        makeItem({ id: "fine", requiredMinutes: 60, endsAt: iso(60 * 24 * 5) }),
+      ],
+      NOW,
+    );
+    expect(plan[0].status).toBe("partial");
+    expect(plan[0].feasibleDropCount).toBe(1);
+    expect(plan[0].totalDropCount).toBe(2);
+  });
+
+  it("orders games earliest-deadline-first", () => {
+    const plan = buildDropsPlan(
+      [
+        makeItem({ id: "y", game: "Y", endsAt: iso(180) }),
+        makeItem({ id: "x", game: "X", endsAt: iso(60) }),
+      ],
+      NOW,
+    );
+    expect(plan.map((e) => e.gameLabel)).toEqual(["X", "Y"]);
+  });
+
+  it("sorts games with no deadline last", () => {
+    const plan = buildDropsPlan(
+      [
+        makeItem({ id: "none", game: "NoDeadline", endsAt: undefined }),
+        makeItem({ id: "dated", game: "Dated", endsAt: iso(60) }),
+      ],
+      NOW,
+    );
+    expect(plan.map((e) => e.gameLabel)).toEqual(["Dated", "NoDeadline"]);
+  });
+
+  it("accumulates watch time across games and skips lost ones (skip-not-block)", () => {
+    // A: 180min, ends 4h → feasible alone, consumes 3h.
+    // B: 120min, ends 4.5h → after A's 3h, completes at 5h > 4.5h → lost, consumes 0.
+    // C: 60min,  ends 6h  → after A only (cursor still 180), completes 4h ≤ 6h → feasible.
+    const plan = buildDropsPlan(
+      [
+        makeItem({ id: "a", game: "A", requiredMinutes: 180, endsAt: iso(240) }),
+        makeItem({ id: "b", game: "B", requiredMinutes: 120, endsAt: iso(270) }),
+        makeItem({ id: "c", game: "C", requiredMinutes: 60, endsAt: iso(360) }),
+      ],
+      NOW,
+    );
+    const byGame = Object.fromEntries(plan.map((e) => [e.gameLabel, e.status]));
+    expect(byGame).toEqual({ A: "ok", B: "lost", C: "ok" });
+  });
+
+  it("treats a malformed endsAt as no deadline (feasible, never NaN)", () => {
+    const plan = buildDropsPlan([makeItem({ endsAt: "not-a-date" })], NOW);
+    expect(plan[0].deadlineMs).toBeNull();
+    expect(plan[0].status).toBe("ok");
+  });
+
+  it("filters out claimed / claimable / excluded / expired / future-start drops", () => {
+    const plan = buildDropsPlan(
+      [
+        makeItem({ id: "claimed", status: "claimed" }),
+        makeItem({ id: "claimable", isClaimable: true }),
+        makeItem({ id: "excluded", excluded: true }),
+        makeItem({ id: "expired", campaignStatus: "EXPIRED" }),
+        makeItem({ id: "future", status: "locked", startsAt: iso(120) }),
+      ],
+      NOW,
+    );
+    expect(plan).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/renderer/shared/domain/dropsPlanner.test.ts`
+Expected: FAIL — cannot resolve `./dropsPlanner` (module does not exist yet).
+
+- [ ] **Step 3: Implement the planner**
+
+Create `src/renderer/shared/domain/dropsPlanner.ts`:
+
+```ts
+import type { InventoryItem } from "@renderer/shared/types";
+import { canEarnDrop } from "./inventory/inventoryRules";
+import { InventoryDrop } from "./dropDomain";
+import { normalizeGameName } from "./gameName";
+
+const MINUTE_MS = 60_000;
+
+export type PlanDrop = {
+  id: string;
+  title: string;
+  requiredMinutes: number;
+  earnedMinutes: number;
+  remainingMinutes: number;
+  deadlineMs: number | null; // finite-parsed endsAt; null = no/non-finite deadline
+  feasible: boolean; // finishes before its OWN deadline in plan order
+};
+
+export type PlanEntry = {
+  gameKey: string; // normalizeGameName(game) — grouping identity
+  gameLabel: string; // original-cased name for display
+  watchMinutes: number; // minutes actually spent here (max remaining among feasible drops)
+  deadlineMs: number | null; // earliest drop deadline → EDF sort + countdown
+  status: "ok" | "partial" | "lost";
+  feasibleDropCount: number;
+  totalDropCount: number;
+  drops: PlanDrop[]; // sorted by remainingMinutes ascending
+};
+
+/** ISO → ms with a finite guard (mirrors InventoryDrop.isExpired parsing). */
+function parseFiniteMs(value: string | undefined): number | null {
+  if (!value) return null;
+  const ms = Date.parse(value);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+/** A drop is plannable if it can still be earned and is not excluded/expired/future. */
+export function isPlannableDrop(item: InventoryItem, now: number): boolean {
+  if (!canEarnDrop(item, { allowUpcoming: true })) return false;
+  if (item.excluded === true) return false;
+  if (new InventoryDrop(item).isExpired(now)) return false;
+  const startsAtMs = parseFiniteMs(item.startsAt);
+  if (startsAtMs !== null && startsAtMs > now) return false;
+  return true;
+}
+
+export function buildDropsPlan(items: InventoryItem[], now: number): PlanEntry[] {
+  // 1. Filter to plannable drops.
+  const plannable = items.filter((it) => isPlannableDrop(it, now));
+
+  // 2. Group by normalized game name (keep first-seen original casing for display).
+  const groups = new Map<string, { label: string; items: InventoryItem[] }>();
+  for (const it of plannable) {
+    const key = normalizeGameName(it.game);
+    const group = groups.get(key);
+    if (group) group.items.push(it);
+    else groups.set(key, { label: it.game, items: [it] });
+  }
+
+  // 3. Build per-game shells: drops (sorted by remaining asc) + earliest deadline.
+  type Shell = {
+    gameKey: string;
+    gameLabel: string;
+    deadlineMs: number | null;
+    drops: Omit<PlanDrop, "feasible">[];
+  };
+  const shells: Shell[] = [];
+  for (const [key, { label, items: groupItems }] of groups) {
+    const drops = groupItems
+      .map((it) => {
+        const drop = new InventoryDrop(it);
+        return {
+          id: drop.id,
+          title: drop.title,
+          requiredMinutes: drop.requiredMinutes,
+          earnedMinutes: drop.earnedMinutes,
+          remainingMinutes: drop.remainingMinutes,
+          deadlineMs: parseFiniteMs(it.endsAt),
+        };
+      })
+      .sort((a, b) => a.remainingMinutes - b.remainingMinutes);
+    const deadlines = drops
+      .map((d) => d.deadlineMs)
+      .filter((v): v is number => v !== null);
+    const deadlineMs = deadlines.length ? Math.min(...deadlines) : null;
+    shells.push({ gameKey: key, gameLabel: label, deadlineMs, drops });
+  }
+
+  // 4. EDF sort: earliest deadline first (null = +Infinity, last). Tiebreak by the
+  //    binding (longest) drop's remaining, then label, for determinism.
+  shells.sort((a, b) => {
+    const da = a.deadlineMs ?? Number.POSITIVE_INFINITY;
+    const db = b.deadlineMs ?? Number.POSITIVE_INFINITY;
+    if (da !== db) return da - db;
+    const wa = Math.max(0, ...a.drops.map((d) => d.remainingMinutes));
+    const wb = Math.max(0, ...b.drops.map((d) => d.remainingMinutes));
+    if (wa !== wb) return wa - wb;
+    return a.gameLabel.localeCompare(b.gameLabel);
+  });
+
+  // 5. Feasibility walk: a cursor of watch-minutes accumulates across games.
+  const result: PlanEntry[] = [];
+  let cursor = 0;
+  for (const shell of shells) {
+    const cursorStart = cursor;
+    const drops: PlanDrop[] = shell.drops.map((d) => {
+      const completionMs = now + (cursorStart + d.remainingMinutes) * MINUTE_MS;
+      const feasible = d.deadlineMs === null || completionMs <= d.deadlineMs;
+      return { ...d, feasible };
+    });
+    const feasibleDrops = drops.filter((d) => d.feasible);
+    const watchMinutes = feasibleDrops.length
+      ? Math.max(...feasibleDrops.map((d) => d.remainingMinutes))
+      : 0;
+    const status: PlanEntry["status"] =
+      feasibleDrops.length === drops.length
+        ? "ok"
+        : feasibleDrops.length > 0
+          ? "partial"
+          : "lost";
+    cursor = cursorStart + watchMinutes;
+    result.push({
+      gameKey: shell.gameKey,
+      gameLabel: shell.gameLabel,
+      watchMinutes,
+      deadlineMs: shell.deadlineMs,
+      status,
+      feasibleDropCount: feasibleDrops.length,
+      totalDropCount: drops.length,
+      drops,
+    });
+  }
+  return result;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run src/renderer/shared/domain/dropsPlanner.test.ts`
+Expected: PASS — all 9 tests green.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `npm run typecheck`
+Expected: exit 0, no errors.
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+npx prettier --write src/renderer/shared/domain/dropsPlanner.ts src/renderer/shared/domain/dropsPlanner.test.ts
+git add src/renderer/shared/domain/dropsPlanner.ts src/renderer/shared/domain/dropsPlanner.test.ts
+git commit -m "feat(planner): pure buildDropsPlan (EDF, per-drop feasibility)"
+```
+
+---
+
+## Task 2: i18n keys
+
+**Files:**
+- Modify: `src/renderer/shared/i18n.tsx` (both the `en` and `de` dictionary blocks)
+
+- [ ] **Step 1: Add the keys to the EN block**
+
+Find the English `queue.header` key (search for `"queue.header":`) and add these seven keys immediately after it, in the same block:
+
+```ts
+    "plan.title": "Plan",
+    "plan.empty": "No open drops scheduled",
+    "plan.remaining": "{time} left",
+    "plan.endsIn": "ends in {time}",
+    "plan.feasibleCount": "{count} of {total} reachable",
+    "plan.atRisk": "{count} of {total} drops won't make it",
+    "plan.lost": "won't make it",
+```
+
+- [ ] **Step 2: Add the keys to the DE block**
+
+Find the German `queue.header` key (the second occurrence of `"queue.header":` in the file) and add these seven keys immediately after it, in the same block:
+
+```ts
+    "plan.title": "Plan",
+    "plan.empty": "Keine offenen Drops eingeplant",
+    "plan.remaining": "noch {time}",
+    "plan.endsIn": "endet in {time}",
+    "plan.feasibleCount": "{count} von {total} schaffbar",
+    "plan.atRisk": "{count} von {total} Drops nicht schaffbar",
+    "plan.lost": "nicht schaffbar",
+```
+
+- [ ] **Step 3: Typecheck + confirm DE parity**
+
+Run: `npm run typecheck`
+Expected: exit 0. Note: the `t()` key type derives from the **EN** block, so typecheck guarantees EN has every key the components use — but a **missing DE key falls back to EN silently and is NOT a type error**. Manually confirm all seven `plan.*` keys are present in the DE block before moving on.
+
+- [ ] **Step 4: Format and commit**
+
+```bash
+npx prettier --write src/renderer/shared/i18n.tsx
+git add src/renderer/shared/i18n.tsx
+git commit -m "feat(planner): add plan.* i18n keys (EN + DE)"
+```
+
+---
+
+## Task 3: `DropsPlanCard` component
+
+**Files:**
+- Create: `src/renderer/features/overview/DropsPlanCard.tsx`
+
+- [ ] **Step 1: Create the component**
+
+Create `src/renderer/features/overview/DropsPlanCard.tsx`:
+
+```tsx
+import * as React from "react";
+import { Card, CardHeader, CardTitle, CardContent } from "@renderer/shared/components/ui/card";
+import { Pill } from "@renderer/shared/components/ui/pill";
+import type { InventoryItem } from "@renderer/shared/types";
+import { useI18n } from "@renderer/shared/i18n";
+import { useVisibleTick } from "@renderer/shared/hooks/useVisibleTick";
+import { cn } from "@renderer/shared/lib/utils";
+import { buildDropsPlan, type PlanEntry } from "@renderer/shared/domain/dropsPlanner";
+import { formatRemaining } from "@renderer/shared/utils";
+
+const URGENT_MS = 2 * 60 * 60 * 1000;
+type TFn = ReturnType<typeof useI18n>["t"];
+
+export type DropsPlanCardProps = {
+  items: InventoryItem[];
+};
+
+export function DropsPlanCard({ items }: DropsPlanCardProps) {
+  const { t } = useI18n();
+  // Owns its own 60s tick (paused while the window is hidden) so feasibility/
+  // countdowns refresh without any useAppModel plumbing.
+  const now = useVisibleTick(60_000);
+  const plan = React.useMemo(() => buildDropsPlan(items, now), [items, now]);
+  const feasibleCount = plan.filter((e) => e.status === "ok").length;
+
+  return (
+    <Card className="bg-[color:var(--dp-bg-elevated)] border-[color:var(--dp-border)] rounded-[var(--dp-radius-lg)]">
+      <CardHeader className="flex flex-row items-center justify-between border-b border-[color:var(--dp-border-soft)] py-3.5">
+        <CardTitle className="font-mono text-[11px] uppercase tracking-[0.14em] text-[color:var(--dp-text-dim)] font-normal">
+          {t("plan.title")}
+        </CardTitle>
+        {plan.length > 0 && (
+          <span className="font-mono text-[10px] text-[color:var(--dp-text-dimmer)]">
+            {t("plan.feasibleCount", { count: feasibleCount, total: plan.length })}
+          </span>
+        )}
+      </CardHeader>
+      <CardContent className="p-0">
+        {plan.length === 0 ? (
+          <div className="px-5 py-8 text-center font-mono text-[11px] text-[color:var(--dp-text-dimmer)]">
+            {t("plan.empty")}
+          </div>
+        ) : (
+          <ul className="divide-y divide-[color:var(--dp-border-soft)]">
+            {plan.map((entry, idx) => (
+              <PlanRow key={entry.gameKey} entry={entry} rank={idx + 1} now={now} t={t} />
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function PlanRow({
+  entry,
+  rank,
+  now,
+  t,
+}: {
+  entry: PlanEntry;
+  rank: number;
+  now: number;
+  t: TFn;
+}) {
+  // Representative = the longest open drop (drops are sorted by remaining asc).
+  const rep = entry.drops[entry.drops.length - 1];
+  const pct =
+    rep.requiredMinutes > 0 ? Math.round((rep.earnedMinutes / rep.requiredMinutes) * 100) : 0;
+  const urgent = entry.deadlineMs !== null && entry.deadlineMs - now < URGENT_MS;
+  const lost = entry.status === "lost";
+  const countdown =
+    entry.deadlineMs !== null
+      ? t("plan.endsIn", {
+          time: formatRemaining(Math.max(0, Math.round((entry.deadlineMs - now) / 1000))),
+        })
+      : null;
+
+  return (
+    <li
+      className={cn(
+        "flex items-center gap-3 px-5 py-3",
+        lost && "opacity-50",
+        urgent && !lost && "border-l-2 border-l-[color:var(--dp-signal-err)]",
+      )}
+    >
+      <span className="font-mono text-[11px] tabular-nums text-[color:var(--dp-text-dimmer)]">
+        {String(rank).padStart(2, "0")}
+      </span>
+      <div className="min-w-0 flex-1">
+        <div
+          className={cn(
+            "truncate text-[13px] text-[color:var(--dp-text)]",
+            lost && "line-through",
+          )}
+        >
+          {entry.gameLabel}
+          <span className="text-[color:var(--dp-text-dimmer)]"> · {rep.title}</span>
+        </div>
+        <div className="mt-1 h-[5px] w-full overflow-hidden rounded-full bg-[color:var(--dp-border)]">
+          <div
+            className="h-full bg-[color:var(--dp-signal-ok)]"
+            style={{ width: `${Math.max(0, Math.min(100, pct))}%` }}
+          />
+        </div>
+      </div>
+      <div className="flex flex-col items-end gap-1">
+        {entry.status === "lost" ? (
+          <Pill tone="err">⚠ {t("plan.lost")}</Pill>
+        ) : entry.status === "partial" ? (
+          <Pill tone="warn">
+            ⚠{" "}
+            {t("plan.atRisk", {
+              count: entry.totalDropCount - entry.feasibleDropCount,
+              total: entry.totalDropCount,
+            })}
+          </Pill>
+        ) : (
+          <Pill tone="ok">
+            ⏳ {t("plan.remaining", { time: formatRemaining(entry.watchMinutes * 60) })}
+          </Pill>
+        )}
+        {countdown && (
+          <span
+            className={cn(
+              "font-mono text-[10px]",
+              urgent
+                ? "text-[color:var(--dp-signal-err)]"
+                : "text-[color:var(--dp-text-dimmer)]",
+            )}
+          >
+            {countdown}
+          </span>
+        )}
+      </div>
+    </li>
+  );
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npm run typecheck`
+Expected: exit 0. (Verifies the `t(...)` numeric params, `Pill` tones, and import paths resolve.)
+
+- [ ] **Step 3: Format and commit**
+
+```bash
+npx prettier --write src/renderer/features/overview/DropsPlanCard.tsx
+git add src/renderer/features/overview/DropsPlanCard.tsx
+git commit -m "feat(planner): DropsPlanCard renders the EDF plan-queue"
+```
+
+---
+
+## Task 4: Mount in Overview + full verification
+
+**Files:**
+- Modify: `src/renderer/features/overview/OverviewView.tsx`
+
+- [ ] **Step 1: Import the card**
+
+In `src/renderer/features/overview/OverviewView.tsx`, add this import alongside the other panel imports near the top of the file:
+
+```tsx
+import { DropsPlanCard } from "./DropsPlanCard";
+```
+
+- [ ] **Step 2: Mount the card under the queue**
+
+In `OverviewView.tsx`, the left column already renders `<QueuePanel items={items} ... />` (around line 108). Add the planner card directly after it, in the same `<div className="flex flex-col gap-6">` column:
+
+```tsx
+        <QueuePanel items={items} activeDrop={activeDrop ?? null} targetGame={activeGame} />
+        <DropsPlanCard items={items} />
+```
+
+(`items` is the already-unwrapped `InventoryItem[]` derived from `inventory: InventoryState` at the top of the component — the same value passed to `QueuePanel`. No new plumbing.)
+
+- [ ] **Step 3: Typecheck**
+
+Run: `npm run typecheck`
+Expected: exit 0 on both tsconfigs.
+
+- [ ] **Step 4: Run the full test suite**
+
+Run: `npm test`
+Expected: PASS — the existing suite plus the 9 new `dropsPlanner` tests.
+
+- [ ] **Step 5: Format-check and build**
+
+Run: `npm run format:check`
+Expected: exit 0 (no files need reformatting). If it fails, run `npm run format` and re-commit.
+
+Run: `npm run build`
+Expected: builds renderer + main/preload with no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/renderer/features/overview/OverviewView.tsx
+git commit -m "feat(planner): mount DropsPlanCard in the Overview"
+```
+
+---
+
+## Self-review notes (already reconciled with the spec)
+
+- **Spec coverage:** filter (excluded/expired/future/canEarnDrop) → Task 1 Step 3 `isPlannableDrop`; normalized grouping → Task 1; per-drop feasibility + partial/lost → Task 1 + tests; EDF + skip-not-block → Task 1 tests; card layout/urgency/empty-state → Task 3; `useVisibleTick` countdown → Task 3; EN+DE i18n → Task 2; Overview mount → Task 4.
+- **Type consistency:** `PlanEntry` / `PlanDrop` field names (`gameKey`, `gameLabel`, `watchMinutes`, `deadlineMs`, `status`, `feasibleDropCount`, `totalDropCount`, `drops`) are identical across the planner, the card, and the tests.
+- **No watch-engine / IPC / `useAppModel` changes** — confirmed by the Files-touched table.

--- a/docs/superpowers/specs/2026-06-13-smart-drops-planner-design.md
+++ b/docs/superpowers/specs/2026-06-13-smart-drops-planner-design.md
@@ -1,0 +1,258 @@
+# Smart Drops Planner — Design
+
+**Date:** 2026-06-13
+**Status:** Approved (brainstorm), ready for implementation plan
+**Branch context:** `main` (new feature branch to be created)
+
+> Revised after an adversarial multi-agent spec review (algorithm / consistency /
+> convention-fit / scope lenses). Notable corrections folded in: feasibility is now computed
+> **per drop** (the earlier min-deadline + max-remaining pairing was incorrect for tiered
+> drops); grouping uses `normalizeGameName`; the filter also drops `excluded` / expired drops;
+> data-flow and the live tick are corrected to the real `OverviewView` / `useVisibleTick`
+> conventions.
+
+## Problem
+
+DropPilot tracks per-drop progress (`requiredMinutes` / `earnedMinutes`) and campaign
+deadlines (`endsAt`), and it auto-selects/switches streams to farm them. But the user has
+no at-a-glance answer to the question that actually matters during a farming session:
+**"which drops can I still finish before they expire, and in what order should I watch
+them?"** Campaigns end at different times; a drop that needs 40 more minutes and expires in
+an hour is urgent, while one that expires in nine days can wait. Today the user has to eyeball
+the inventory and do this math in their head.
+
+The Smart Drops Planner surfaces a computed, **deadline-ordered** plan so the answer is
+visible without manual reasoning. It is **advisory only** — it changes nothing about how the
+watch engine selects channels; it reads existing inventory data and presents a recommendation.
+
+## Goal & scope
+
+A new **Plan-Queue card** in the existing Overview view that renders an Earliest-Deadline-First
+(EDF) plan over the user's earnable drops, **grouped by game**, with per-entry watch-time, a
+deadline countdown, and a feasibility flag (`ok` / `partial` / `lost`).
+
+### In scope (v1)
+
+- Pure planning function `buildDropsPlan(items, now)` → ordered `PlanEntry[]`.
+- `DropsPlanCard` in `features/overview/` rendering the queue (Layout "A · Plan-Queue").
+- Live countdown (minute granularity) via the existing `useVisibleTick`.
+- Empty-state, urgency coloring, infeasible / partial treatment.
+- i18n keys in **EN + DE**.
+
+### Explicitly out of scope (YAGNI)
+
+- **Driving the watch engine / auto-reordering the priority list.** Advisory only. No change
+  to `shared/hooks/watch/`, priority orchestration, IPC, the Twitch layer, or `useAppModel`.
+- **Priority-list weighting.** The plan is *pure EDF* by deliberate decision — earliest deadline
+  wins regardless of the user's priority order. (Priority remains what the watch engine obeys;
+  the planner is a separate, deadline-focused lens.)
+- **Deadline-Timeline / Gantt visualization** (the rejected Layout "B"). The compact queue is v1.
+- **Click-to-jump from a plan row to the Inventory view.** Nice-to-have, deferred.
+- **A dedicated top-nav "Planner" view.** It lives as a card in Overview.
+- **Projected wall-clock completion time as a visible field.** The completion timestamp is
+  computed internally for feasibility but not rendered (the pill shows remaining *duration*).
+
+## Data flow
+
+No new data, no new IPC. The card consumes the **already-unwrapped `items: InventoryItem[]`**
+that `OverviewView` derives from its `inventory: InventoryState` prop
+(`OverviewView.tsx:73-78` — the same `items` it hands to `QueuePanel`). The card is mounted in
+`OverviewView`'s left column and passed `items={items}`; it owns its own clock tick (see *Live
+countdown*). It does **not** call `useInventory` itself and does **not** require any
+`useAppModel` / `AppContent` plumbing.
+
+> Correction vs. the naïve assumption: `useInventory` and `OverviewView` expose `inventory` as
+> an `InventoryState` discriminated union (`{ status: "idle" | "loading" | "ready" | "error";
+> items? }`), **not** a bare `InventoryItem[]`. The unwrapping already exists in `OverviewView`;
+> the card just reuses the local `items`.
+
+`InventoryItem` (renderer mirror in `src/renderer/shared/types.ts`) already carries every field
+the planner needs: `id`, `game`, `title`, `requiredMinutes`, `earnedMinutes`, `status`,
+`startsAt?`, `endsAt?`, `blocked?`, `isClaimable?`, `excluded?`, `campaignStatus?`,
+`blockingReasonHints?`.
+
+## The planner (`src/renderer/shared/domain/dropsPlanner.ts`)
+
+A single pure, exported function. No React, no I/O, clock injected via `now`. Sibling test
+`dropsPlanner.test.ts`. It builds on the existing `InventoryDrop` domain class
+(`shared/domain/dropDomain.ts`) for renderer-safe `remainingMinutes` / `isExpired(now)`, and
+parses `endsAt` with a finite guard mirroring `InventoryDrop.isExpired` (`Date.parse` +
+`Number.isFinite`) — never raw `Date.parse` into arithmetic.
+
+### Types
+
+```ts
+export type PlanDrop = {
+  id: string;
+  title: string;
+  remainingMinutes: number;
+  deadlineMs: number | null;   // finite-parsed endsAt; null = no/!finite deadline
+  feasible: boolean;           // finishes before its OWN deadline in plan order
+};
+
+export type PlanEntry = {
+  gameKey: string;             // normalizeGameName(game) — grouping identity
+  gameLabel: string;           // original-cased name for display
+  watchMinutes: number;        // minutes you'd actually spend here (see step 4)
+  deadlineMs: number | null;   // earliest drop deadline in the game → EDF sort + countdown
+  status: "ok" | "partial" | "lost";
+  feasibleDropCount: number;
+  totalDropCount: number;
+  drops: PlanDrop[];           // per-drop detail (display + tests), sorted by remaining asc
+};
+
+export function buildDropsPlan(items: InventoryItem[], now: number): PlanEntry[];
+```
+
+### Algorithm
+
+1. **Filter** to genuinely earnable drops. Keep `item` iff **all** hold:
+   - `canEarnDrop(item, { allowUpcoming: true })` — from `shared/domain/inventory/inventoryRules.ts`.
+     On **real** data this already excludes `claimed`, `blocked`, `isClaimable`, hard-watching-
+     blocked (incl. `campaign_not_started` / `campaign_expired` hints), and completed
+     (`earned >= required`) drops.
+   - `item.excluded !== true` — `canEarnDrop` does **not** check `excluded`; user-excluded drops
+     must not appear.
+   - `!new InventoryDrop(item).isExpired(now)` — guards `campaignStatus === "EXPIRED"` and
+     past-`endsAt` even when no blocker hint is present.
+   - `startsAt` absent **or** finite-parsed `startsAt <= now`.
+
+   > Why the last three are needed even though `canEarnDrop` looks sufficient: they are
+   > load-bearing for **demo mode** and clock-skew. Demo inventory (`demoData.ts`) carries no
+   > `blockingReasonHints` / `blocked` / `isClaimable`, so future-start, excluded, and
+   > status-expired demo drops would otherwise slip through `canEarnDrop`. (The "same data
+   > shape" convenience claim is therefore softened: demo lacks the blocker metadata real data
+   > has; these explicit checks compensate so demo and production plans agree.)
+
+2. **Group** the surviving drops by `normalizeGameName(item.game)` (`shared/domain/gameName.ts`)
+   — **not** the raw string, which would split e.g. `"Marvel Rivals"` from `"marvel rivals "`
+   into two entries. Keep one original-cased `gameLabel` per group (first seen) for display.
+
+3. **Per-game aggregates:**
+   - `deadlineMs` = the **minimum** finite-parsed `endsAt` over the game's drops; `null` if none
+     have a finite deadline. Drives EDF ordering and the countdown.
+   - Each drop keeps its **own** `deadlineMs` for feasibility (step 4) — deadlines are *not*
+     collapsed into the aggregate for the feasibility test.
+
+4. **Sort & feasibility walk.** Sort games EDF by `deadlineMs` ascending (`null` → `+Infinity`,
+   sorted last), tiebreak by `watchMinutes` ascending then `gameLabel`. Walk the sorted games
+   with a `cursor` (watch minutes elapsed before this game; start `0`). For each game:
+   - `cursorStart = cursor`.
+   - For each drop `d` (sorted by `remainingMinutes` asc): let
+     `completionMs = now + (cursorStart + d.remainingMinutes) * 60_000`;
+     `d.feasible = d.deadlineMs == null || completionMs <= d.deadlineMs`.
+   - `feasibleDrops = drops.filter(feasible)`;
+     `watchMinutes = feasibleDrops.length ? max(d.remainingMinutes over feasibleDrops) : 0`.
+   - `status = allFeasible ? "ok" : feasibleDrops.length ? "partial" : "lost"`.
+   - `cursor = cursorStart + watchMinutes`.
+
+   **Why per-drop, not min-deadline vs. max-remaining:** within one game all drops progress in
+   parallel while you watch it, so each drop finishes at `cursorStart + its own remaining`, and
+   each is feasible against *its own* deadline. Pairing the game's earliest deadline with its
+   longest remaining (the prior design) asked a question matching no real drop — a short
+   low-tier (40 min deadline) plus a long high-tier (9-day deadline) would be wrongly flagged
+   "lost". `watchMinutes` counts only the time needed to harvest the *still-achievable* drops:
+   a fully-`lost` game consumes `0` (you'd skip it), so later games stay plannable — the EDF
+   "skip-don't-block" property, now correct at drop granularity.
+
+5. **Return** the `PlanEntry[]` in EDF order. `lost` / `partial` entries stay in their
+   deadline-sorted position (they are **not** re-sorted to the bottom); the UI de-emphasizes
+   them visually.
+
+### Edge cases (covered in the pure function + tests)
+
+- **Empty / all-filtered input** → `[]`.
+- **No `endsAt` anywhere** → all `deadlineMs = null`, every drop feasible, `status = "ok"`,
+  games sorted by `watchMinutes`.
+- **Malformed / non-finite `endsAt`** → finite guard yields `null` (treated as no deadline);
+  never `NaN` poisoning `min`/comparisons.
+- **Past `endsAt` or `campaignStatus === "EXPIRED"`** → excluded at the filter (step 1); does
+  not reach the plan.
+- **Single game, mixed-deadline tiers** → one entry; per-drop feasibility may produce
+  `status = "partial"` (some tiers reachable, some not).
+
+## UI (`src/renderer/features/overview/DropsPlanCard.tsx`)
+
+A card consuming `items` and a `now` tick; all logic stays in `buildDropsPlan`.
+
+- **Header:** title + reachable count `plan.feasibleCount` = "{count} of {total} reachable",
+  where `total = plan.length` (all entries) and `count` = entries with `status === "ok"`.
+- **Row (per `PlanEntry`):** rank badge · `gameLabel` + representative drop title · progress bar
+  (`earned/required` of the representative — the longest open drop) · remaining-duration pill
+  (`plan.remaining` = "{time} left", from `watchMinutes`) · deadline countdown (`plan.endsIn` =
+  "ends in {time}", from `deadlineMs - now`).
+- **Urgency:** rows with `deadlineMs - now < 2h` use `--dp-signal-*` (red) accents; others neutral.
+- **`partial` rows:** amber accent + badge `plan.atRisk` = "{count} of {total} drops won't make
+  it" (`count = totalDropCount - feasibleDropCount`, `total = totalDropCount`).
+- **`lost` rows:** struck-through title + badge `plan.lost` = "won't make it"; no remaining pill.
+  The ⚠ glyph is prepended by the component, not baked into the i18n string (keeps EN/DE
+  symmetric).
+- **Empty state:** `plan.empty` = "No open drops scheduled".
+- Styled with `--dp-*` tokens and `dp-*` component variants per the design-system convention.
+
+### Live countdown
+
+Deadlines/ETAs tick. The card sources `now` from the existing
+`useVisibleTick(60_000)` (`shared/hooks/useVisibleTick.ts`) — which already **pauses while the
+window is hidden**, avoiding background re-renders — and recomputes `buildDropsPlan` via
+`useMemo([items, now])`. Per-row countdowns may additionally render through the `TimeText`
+leaf (`shared/components/TimeText.tsx`) so time-driven re-renders stay scoped to the countdown
+leaves rather than the whole card. The bespoke `setInterval` from the first draft is dropped.
+`DropsPlanCard` deliberately owns this tick — a small, isolated exception to the otherwise
+prop-driven, stateless Overview panels — which is why no `useAppModel` plumbing is needed.
+
+## i18n
+
+New flat dotted keys (matching `i18n.tsx`'s existing style; `format()` interpolates `/\{(\w+)\}/g`)
+added to **both** the `en` and `de` blocks of `src/renderer/shared/i18n.tsx`. Descriptive
+placeholder tokens only (`{time}`, `{count}`, `{total}`) — consistent with the file's existing
+keys (no single-letter tokens). There is no existing `plan.*` namespace, so all keys are new in
+both blocks:
+
+| key | EN | DE |
+| --- | --- | --- |
+| `plan.title` | Plan | Plan |
+| `plan.empty` | No open drops scheduled | Keine offenen Drops eingeplant |
+| `plan.remaining` | {time} left | noch {time} |
+| `plan.endsIn` | ends in {time} | endet in {time} |
+| `plan.feasibleCount` | {count} of {total} reachable | {count} von {total} schaffbar |
+| `plan.atRisk` | {count} of {total} drops won't make it | {count} von {total} Drops nicht schaffbar |
+| `plan.lost` | won't make it | nicht schaffbar |
+
+Phrasing is plural-agnostic ("{count} of {total}", "noch {time}"), so flat keys are acceptable
+here rather than `.one`/`.other` variants. `{time}` is a preformatted duration/countdown string
+produced by the existing time-formatting util the card uses for the pill and countdown.
+
+## Testing
+
+`dropsPlanner.test.ts` (Vitest, pure — no rendered components, per project convention):
+
+- **Per-game grouping** via `normalizeGameName`: differently-cased/whitespaced `game` strings of
+  the same logical game collapse into one entry.
+- **Per-drop feasibility** (regression guard for the corrected model): a game with a short
+  low-tier (near deadline) and a long high-tier (far deadline) is `status: "ok"` with both drops
+  feasible — *not* wrongly `lost`.
+- **`partial` status**: a game where one tier is reachable and another is not.
+- **EDF ordering**, including `null`-deadline entries last and the `watchMinutes` tiebreak.
+- **Feasibility walk**: cumulative `cursor`, `lost` games consuming `0` so later games stay
+  feasible; exact values for a hand-computed scenario.
+- **Filtering**: `claimed` / `blocked` / `isClaimable` / completed / `excluded` /
+  `campaignStatus === "EXPIRED"` / future-`startsAt` drops excluded.
+- **Malformed `endsAt`** → treated as no deadline (feasible), never `NaN`.
+- **Empty input** → `[]`.
+
+The `DropsPlanCard` component is not unit-tested (no `@testing-library/react`); all behavior
+lives in the pure function.
+
+## Files touched
+
+| File | Change |
+| --- | --- |
+| `src/renderer/shared/domain/dropsPlanner.ts` | **new** — `buildDropsPlan` + types |
+| `src/renderer/shared/domain/dropsPlanner.test.ts` | **new** — unit tests |
+| `src/renderer/features/overview/DropsPlanCard.tsx` | **new** — Plan-Queue card |
+| `src/renderer/features/overview/OverviewView.tsx` | mount `<DropsPlanCard items={items} />` |
+| `src/renderer/shared/i18n.tsx` | new EN + DE `plan.*` keys |
+
+No changes to `src/main`, IPC, preload, the watch engine, priority logic, `useAppModel`, or
+`AppContent`.

--- a/docs/superpowers/specs/2026-06-13-smart-drops-planner-priority-aware-design.md
+++ b/docs/superpowers/specs/2026-06-13-smart-drops-planner-priority-aware-design.md
@@ -1,0 +1,151 @@
+# Smart Drops Planner — Priority-Aware Ordering (Addendum)
+
+**Date:** 2026-06-13
+**Status:** Approved (brainstorm), ready for implementation plan
+**Branch context:** `feat/smart-drops-planner` (extends PR #59)
+**Extends:** `2026-06-13-smart-drops-planner-design.md`
+
+## Problem
+
+The shipped planner sorts **all** games by pure EDF (earliest deadline first), deliberately
+ignoring the user's priority list. That conflicts with how the watch engine actually behaves:
+
+- **`obeyPriority` ON (strict):** the engine farms **only** priority-list games, in priority
+  order, with **no fallback** (it goes idle if none are actionable).
+- **`obeyPriority` OFF (permissive):** the engine farms priority games first (in priority
+  order), then falls back to any game with earnable drops.
+
+So when a user runs strict + a priority list, the planner advises "watch game X first" for games
+the engine will **never** touch, and orders priority games by deadline rather than the priority
+order the engine actually follows. The advice contradicts reality.
+
+## Goal
+
+Make the plan **mirror the engine's actual farming order**, and turn deadlines into a **risk
+warning layer** rather than the sort key. The plan answers: *"given how the engine actually
+farms (my priority order), which drops will I still finish before they expire?"* — e.g. "Rust is
+priority #4 but expires in 2h → you won't reach it."
+
+Still **advisory only**: display-only, reads settings, no engine/IPC/`useAppModel` changes.
+
+## Ordering model (replaces pure-EDF sort)
+
+The plan's game order is the **engine order**:
+
+| `priorityGames` | `obeyPriority` | Games shown | Order |
+| --- | --- | --- | --- |
+| non-empty | **true** (strict) | priority games only | priority order |
+| non-empty | **false** (permissive) | priority games + fallback games | priority order, then fallback (EDF) |
+| **empty** | false | all games | pure EDF (unchanged from v1) |
+| **empty** | true | none | empty plan |
+
+- A **priority game** = a game group whose `normalizeGameName(gameLabel)` matches a
+  `normalizeGameName(priorityGames[i])`. Its `priorityRank` = `i + 1` (1-based; priority order).
+  A priority game with no earnable drops simply produces no row (not shown).
+- **Fallback games** (permissive only) = the remaining game groups, sorted among themselves by
+  the existing EDF rule (`deadlineMs` asc, null last, tiebreak by longest remaining then key).
+- The **feasibility walk runs along this combined order** (unchanged mechanics): a cursor
+  accumulates `watchMinutes` game by game; each drop is feasible iff it completes before its own
+  deadline at its position in the order. A game you won't reach in time is flagged
+  `partial`/`lost` and **stays in its priority position** (never re-sorted up).
+
+The v1 tested core is otherwise unchanged: filtering (`isPlannableDrop`), per-game grouping via
+`normalizeGameName`, per-drop parallel-deadline feasibility, and `ok`/`partial`/`lost` status.
+
+> **Implementation note (DRY):** the priority-first / strict-no-fallback partition mirrors
+> `buildLivePriorityPlan` in `shared/hooks/priority/usePriorityOrchestration.ts`. Reuse
+> `normalizeGameName` for matching; if a clean pure ordering helper can be shared with the
+> orchestration without dragging in hook state, prefer that over duplicating the rule. Otherwise
+> implement the partition inline in the pure planner and keep it consistent with the orchestration
+> semantics.
+
+## API change (`dropsPlanner.ts`)
+
+`buildDropsPlan` gains an optional third argument; omitting it preserves v1 behavior (so existing
+2-arg call sites and tests are unaffected):
+
+```ts
+export type DropsPlanOptions = {
+  priorityGames: string[];
+  obeyPriority: boolean;
+};
+
+export function buildDropsPlan(
+  items: InventoryItem[],
+  now: number,
+  options?: DropsPlanOptions, // default: { priorityGames: [], obeyPriority: false } → pure EDF
+): PlanEntry[];
+```
+
+`PlanEntry` gains two fields (everything else unchanged):
+
+```ts
+  isPriority: boolean;          // on the priority list
+  priorityRank: number | null;  // 1-based priority position; null for fallback games
+```
+
+## UI (`DropsPlanCard.tsx`)
+
+- The card reads `const { priorityGames, obeyPriority } = useSettingsStore();` and passes them as
+  `buildDropsPlan(items, now, { priorityGames, obeyPriority })`. **No new props, no `OverviewView`
+  / `useAppModel` plumbing** (it stays mounted as `<DropsPlanCard items={items} />`).
+- **Rank cell:** priority games show their priority position — `#{priorityRank}` (e.g. `#1`).
+  Fallback games show a `·` marker instead of a number.
+- **Fallback divider (permissive only):** when the plan contains at least one priority entry
+  **and** at least one fallback entry, render a thin divider row labelled `plan.fallbackDivider`
+  immediately before the first fallback entry (rendered as `— {label} —`). In strict mode there
+  are no fallback rows, so no divider appears.
+- Status pills (`ok`/`partial`/`lost`), the at-risk/lost treatment, progress bar, deadline
+  countdown, urgency accent, and the `plan.feasibleCount` header are unchanged from v1.
+- Empty state (`plan.empty`) covers the strict-with-no-actionable-priority-game case (the plan is
+  simply empty). Surfacing expiring non-priority games as a nudge was explicitly considered and
+  declined for this iteration (YAGNI).
+
+## i18n
+
+One new key in **both** EN and DE blocks of `i18n.tsx`:
+
+| key | EN | DE |
+| --- | --- | --- |
+| `plan.fallbackDivider` | then (fallback) | danach (Fallback) |
+
+(The component wraps it as `— then (fallback) —`; dashes are added in JSX, not the string.)
+
+## Edge cases
+
+- **Empty `priorityGames`, permissive** → no priority groups → pure EDF over all games (v1 behavior preserved).
+- **Empty `priorityGames`, strict** → no priority groups and no fallback → empty plan.
+- **Priority game not in inventory / no earnable drops** → no row (absent), no error.
+- **A priority game that is also expired/excluded/etc.** → already removed by `isPlannableDrop`
+  before partitioning.
+- **Duplicate or differently-cased priority entries** → matched via `normalizeGameName`; the
+  lowest matching index wins for `priorityRank`.
+
+## Testing (`dropsPlanner.test.ts`)
+
+Add to the existing suite (all v1 tests must still pass unchanged):
+
+- Strict mode shows **only** priority games, in priority order (non-priority games excluded).
+- Permissive mode: priority games first (priority order), then fallback games EDF-sorted; the
+  boundary is detectable via `isPriority` / `priorityRank`.
+- `priorityRank` equals the 1-based index in `priorityGames` (and matches via `normalizeGameName`,
+  e.g. `"rust"` in the list matches a `"Rust"` game).
+- Feasibility along priority order: a later priority game becomes `lost` because earlier
+  priority games consume the watch-minute budget (deadline-risk warning), while EDF order would
+  have made it feasible — proves order drives feasibility.
+- Empty `priorityGames` + permissive → identical result to a v1 (no-options) call (pure EDF).
+- Empty `priorityGames` + strict → `[]`.
+
+The card remains untested (project convention); all logic stays in the pure function.
+
+## Files touched
+
+| File | Change |
+| --- | --- |
+| `src/renderer/shared/domain/dropsPlanner.ts` | add `DropsPlanOptions`, partition/order logic, `isPriority`/`priorityRank` |
+| `src/renderer/shared/domain/dropsPlanner.test.ts` | new priority-ordering tests |
+| `src/renderer/features/overview/DropsPlanCard.tsx` | read `useSettingsStore`, pass options, priority rank + fallback divider |
+| `src/renderer/shared/i18n.tsx` | new `plan.fallbackDivider` (EN + DE) |
+
+No changes to `src/main`, IPC, preload, the watch engine, priority orchestration, `useAppModel`,
+`AppContent`, or `OverviewView`.

--- a/docs/superpowers/specs/2026-06-13-smart-drops-planner-priority-aware-design.md
+++ b/docs/superpowers/specs/2026-06-13-smart-drops-planner-priority-aware-design.md
@@ -86,9 +86,15 @@ export function buildDropsPlan(
 
 ## UI (`DropsPlanCard.tsx`)
 
-- The card reads `const { priorityGames, obeyPriority } = useSettingsStore();` and passes them as
-  `buildDropsPlan(items, now, { priorityGames, obeyPriority })`. **No new props, no `OverviewView`
-  / `useAppModel` plumbing** (it stays mounted as `<DropsPlanCard items={items} />`).
+- The card receives `priorityGames: string[]` and `obeyPriority: boolean` as **props** and passes
+  them as `buildDropsPlan(items, now, { priorityGames, obeyPriority })`. They are threaded from
+  `useAppModel` (which already holds them) through `overviewProps` → `OverviewView` →
+  `<DropsPlanCard items={items} priorityGames={priorityGames} obeyPriority={obeyPriority} />`.
+  > **Why props, not `useSettingsStore()` in the card:** `useSettingsStore` is a plain
+  > `useState`/`useEffect` hook with **no shared store/Context** — calling it a second time spins up
+  > a *duplicate* settings instance with its own IPC load/persist, diverging from the canonical
+  > store in `useAppModel`. The values must be threaded, not re-read. (Corrects the earlier
+  > "read the hook directly" assumption.)
 - **Rank cell:** priority games show their priority position — `#{priorityRank}` (e.g. `#1`).
   Fallback games show a `·` marker instead of a number.
 - **Fallback divider (permissive only):** when the plan contains at least one priority entry
@@ -144,8 +150,9 @@ The card remains untested (project convention); all logic stays in the pure func
 | --- | --- |
 | `src/renderer/shared/domain/dropsPlanner.ts` | add `DropsPlanOptions`, partition/order logic, `isPriority`/`priorityRank` |
 | `src/renderer/shared/domain/dropsPlanner.test.ts` | new priority-ordering tests |
-| `src/renderer/features/overview/DropsPlanCard.tsx` | read `useSettingsStore`, pass options, priority rank + fallback divider |
+| `src/renderer/features/overview/DropsPlanCard.tsx` | accept `priorityGames`/`obeyPriority` props, pass options, priority rank + fallback divider |
+| `src/renderer/features/overview/OverviewView.tsx` | add the two fields to `OverviewProps`, pass them to `DropsPlanCard` |
+| `src/renderer/shared/hooks/app/useAppModel.ts` | add `priorityGames` / `obeyPriority` to `overviewProps` |
 | `src/renderer/shared/i18n.tsx` | new `plan.fallbackDivider` (EN + DE) |
 
-No changes to `src/main`, IPC, preload, the watch engine, priority orchestration, `useAppModel`,
-`AppContent`, or `OverviewView`.
+No changes to `src/main`, IPC, preload, the watch engine, priority orchestration, or `AppContent`.

--- a/src/renderer/features/overview/DropsPlanCard.tsx
+++ b/src/renderer/features/overview/DropsPlanCard.tsx
@@ -9,6 +9,7 @@ import { buildDropsPlan, type PlanEntry } from "@renderer/shared/domain/dropsPla
 import { formatRemaining } from "@renderer/shared/utils";
 
 const URGENT_MS = 2 * 60 * 60 * 1000;
+const EMPTY_GAMES: string[] = [];
 type TFn = ReturnType<typeof useI18n>["t"];
 
 export type DropsPlanCardProps = {
@@ -19,7 +20,7 @@ export type DropsPlanCardProps = {
 
 export function DropsPlanCard({
   items,
-  priorityGames = [],
+  priorityGames = EMPTY_GAMES,
   obeyPriority = false,
 }: DropsPlanCardProps) {
   const { t } = useI18n();
@@ -56,7 +57,10 @@ export function DropsPlanCard({
             {plan.map((entry, idx) => (
               <React.Fragment key={entry.gameKey}>
                 {idx === firstFallbackIdx && firstFallbackIdx > 0 && (
-                  <li className="px-5 py-1.5 text-center font-mono text-[10px] uppercase tracking-[0.12em] text-[color:var(--dp-text-dimmer)]">
+                  <li
+                    aria-hidden="true"
+                    className="border-t-0 px-5 py-1.5 text-center font-mono text-[10px] uppercase tracking-[0.12em] text-[color:var(--dp-text-dimmer)]"
+                  >
                     — {t("plan.fallbackDivider")} —
                   </li>
                 )}

--- a/src/renderer/features/overview/DropsPlanCard.tsx
+++ b/src/renderer/features/overview/DropsPlanCard.tsx
@@ -7,22 +7,32 @@ import { useVisibleTick } from "@renderer/shared/hooks/useVisibleTick";
 import { cn } from "@renderer/shared/lib/utils";
 import { buildDropsPlan, type PlanEntry } from "@renderer/shared/domain/dropsPlanner";
 import { formatRemaining } from "@renderer/shared/utils";
-import { padRank } from "./formatters";
 
 const URGENT_MS = 2 * 60 * 60 * 1000;
 type TFn = ReturnType<typeof useI18n>["t"];
 
 export type DropsPlanCardProps = {
   items: InventoryItem[];
+  priorityGames?: string[];
+  obeyPriority?: boolean;
 };
 
-export function DropsPlanCard({ items }: DropsPlanCardProps) {
+export function DropsPlanCard({
+  items,
+  priorityGames = [],
+  obeyPriority = false,
+}: DropsPlanCardProps) {
   const { t } = useI18n();
   // Owns its own 60s tick (paused while the window is hidden) so feasibility/
   // countdowns refresh without any useAppModel plumbing.
   const now = useVisibleTick(60_000);
-  const plan = React.useMemo(() => buildDropsPlan(items, now), [items, now]);
+  const plan = React.useMemo(
+    () => buildDropsPlan(items, now, { priorityGames, obeyPriority }),
+    [items, now, priorityGames, obeyPriority],
+  );
   const feasibleCount = plan.filter((e) => e.status === "ok").length;
+  // Boundary between priority games and the permissive fallback tail.
+  const firstFallbackIdx = plan.findIndex((e) => !e.isPriority);
 
   return (
     <Card className="bg-[color:var(--dp-bg-elevated)] border-[color:var(--dp-border)] rounded-[var(--dp-radius-lg)]">
@@ -44,7 +54,14 @@ export function DropsPlanCard({ items }: DropsPlanCardProps) {
         ) : (
           <ul className="divide-y divide-[color:var(--dp-border-soft)]">
             {plan.map((entry, idx) => (
-              <PlanRow key={entry.gameKey} entry={entry} rank={idx + 1} now={now} t={t} />
+              <React.Fragment key={entry.gameKey}>
+                {idx === firstFallbackIdx && firstFallbackIdx > 0 && (
+                  <li className="px-5 py-1.5 text-center font-mono text-[10px] uppercase tracking-[0.12em] text-[color:var(--dp-text-dimmer)]">
+                    — {t("plan.fallbackDivider")} —
+                  </li>
+                )}
+                <PlanRow entry={entry} now={now} t={t} />
+              </React.Fragment>
             ))}
           </ul>
         )}
@@ -53,7 +70,7 @@ export function DropsPlanCard({ items }: DropsPlanCardProps) {
   );
 }
 
-function PlanRow({ entry, rank, now, t }: { entry: PlanEntry; rank: number; now: number; t: TFn }) {
+function PlanRow({ entry, now, t }: { entry: PlanEntry; now: number; t: TFn }) {
   // Representative = the longest open drop (drops are sorted by remaining asc).
   const rep = entry.drops[entry.drops.length - 1];
   const pct =
@@ -78,7 +95,7 @@ function PlanRow({ entry, rank, now, t }: { entry: PlanEntry; rank: number; now:
       )}
     >
       <span className="font-mono text-[11px] tabular-nums text-[color:var(--dp-text-dimmer)]">
-        {padRank(rank)}
+        {entry.priorityRank !== null ? `#${entry.priorityRank}` : "·"}
       </span>
       <div className="min-w-0 flex-1">
         <div

--- a/src/renderer/features/overview/DropsPlanCard.tsx
+++ b/src/renderer/features/overview/DropsPlanCard.tsx
@@ -111,7 +111,9 @@ function PlanRow({ entry, rank, now, t }: { entry: PlanEntry; rank: number; now:
           <span
             className={cn(
               "font-mono text-[10px]",
-              urgent ? "text-[color:var(--dp-signal-err)]" : "text-[color:var(--dp-text-dimmer)]",
+              urgent && !lost
+                ? "text-[color:var(--dp-signal-err)]"
+                : "text-[color:var(--dp-text-dimmer)]",
             )}
           >
             {countdown}

--- a/src/renderer/features/overview/DropsPlanCard.tsx
+++ b/src/renderer/features/overview/DropsPlanCard.tsx
@@ -7,6 +7,7 @@ import { useVisibleTick } from "@renderer/shared/hooks/useVisibleTick";
 import { cn } from "@renderer/shared/lib/utils";
 import { buildDropsPlan, type PlanEntry } from "@renderer/shared/domain/dropsPlanner";
 import { formatRemaining } from "@renderer/shared/utils";
+import { padRank } from "./formatters";
 
 const URGENT_MS = 2 * 60 * 60 * 1000;
 type TFn = ReturnType<typeof useI18n>["t"];
@@ -56,9 +57,11 @@ function PlanRow({ entry, rank, now, t }: { entry: PlanEntry; rank: number; now:
   // Representative = the longest open drop (drops are sorted by remaining asc).
   const rep = entry.drops[entry.drops.length - 1];
   const pct =
-    rep.requiredMinutes > 0 ? Math.round((rep.earnedMinutes / rep.requiredMinutes) * 100) : 0;
-  const urgent = entry.deadlineMs !== null && entry.deadlineMs - now < URGENT_MS;
+    rep.requiredMinutes > 0
+      ? Math.max(0, Math.min(100, Math.round((rep.earnedMinutes / rep.requiredMinutes) * 100)))
+      : 0;
   const lost = entry.status === "lost";
+  const urgent = !lost && entry.deadlineMs !== null && entry.deadlineMs - now < URGENT_MS;
   const countdown =
     entry.deadlineMs !== null
       ? t("plan.endsIn", {
@@ -71,11 +74,11 @@ function PlanRow({ entry, rank, now, t }: { entry: PlanEntry; rank: number; now:
       className={cn(
         "flex items-center gap-3 px-5 py-3",
         lost && "opacity-50",
-        urgent && !lost && "border-l-2 border-l-[color:var(--dp-signal-err)]",
+        urgent && "border-l-2 border-l-[color:var(--dp-signal-err)]",
       )}
     >
       <span className="font-mono text-[11px] tabular-nums text-[color:var(--dp-text-dimmer)]">
-        {String(rank).padStart(2, "0")}
+        {padRank(rank)}
       </span>
       <div className="min-w-0 flex-1">
         <div
@@ -84,19 +87,25 @@ function PlanRow({ entry, rank, now, t }: { entry: PlanEntry; rank: number; now:
           {entry.gameLabel}
           <span className="text-[color:var(--dp-text-dimmer)]"> · {rep.title}</span>
         </div>
-        <div className="mt-1 h-[5px] w-full overflow-hidden rounded-full bg-[color:var(--dp-border)]">
-          <div
-            className="h-full bg-[color:var(--dp-signal-ok)]"
-            style={{ width: `${Math.max(0, Math.min(100, pct))}%` }}
-          />
+        <div
+          role="progressbar"
+          aria-valuenow={pct}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label={entry.gameLabel}
+          className="mt-1 h-[5px] w-full overflow-hidden rounded-full bg-[color:var(--dp-border)]"
+        >
+          <div className="h-full bg-[color:var(--dp-signal-ok)]" style={{ width: `${pct}%` }} />
         </div>
       </div>
       <div className="flex flex-col items-end gap-1">
         {entry.status === "lost" ? (
-          <Pill tone="err">⚠ {t("plan.lost")}</Pill>
+          <Pill tone="err">
+            <span aria-hidden="true">⚠</span> {t("plan.lost")}
+          </Pill>
         ) : entry.status === "partial" ? (
           <Pill tone="warn">
-            ⚠{" "}
+            <span aria-hidden="true">⚠</span>{" "}
             {t("plan.atRisk", {
               count: entry.totalDropCount - entry.feasibleDropCount,
               total: entry.totalDropCount,
@@ -104,16 +113,16 @@ function PlanRow({ entry, rank, now, t }: { entry: PlanEntry; rank: number; now:
           </Pill>
         ) : (
           <Pill tone="ok">
-            ⏳ {t("plan.remaining", { time: formatRemaining(entry.watchMinutes * 60) })}
+            {/* watchMinutes is in minutes; *60 → seconds for formatRemaining */}
+            <span aria-hidden="true">⏳</span>{" "}
+            {t("plan.remaining", { time: formatRemaining(entry.watchMinutes * 60) })}
           </Pill>
         )}
         {countdown && (
           <span
             className={cn(
               "font-mono text-[10px]",
-              urgent && !lost
-                ? "text-[color:var(--dp-signal-err)]"
-                : "text-[color:var(--dp-text-dimmer)]",
+              urgent ? "text-[color:var(--dp-signal-err)]" : "text-[color:var(--dp-text-dimmer)]",
             )}
           >
             {countdown}

--- a/src/renderer/features/overview/DropsPlanCard.tsx
+++ b/src/renderer/features/overview/DropsPlanCard.tsx
@@ -1,0 +1,123 @@
+import * as React from "react";
+import { Card, CardHeader, CardTitle, CardContent } from "@renderer/shared/components/ui/card";
+import { Pill } from "@renderer/shared/components/ui/pill";
+import type { InventoryItem } from "@renderer/shared/types";
+import { useI18n } from "@renderer/shared/i18n";
+import { useVisibleTick } from "@renderer/shared/hooks/useVisibleTick";
+import { cn } from "@renderer/shared/lib/utils";
+import { buildDropsPlan, type PlanEntry } from "@renderer/shared/domain/dropsPlanner";
+import { formatRemaining } from "@renderer/shared/utils";
+
+const URGENT_MS = 2 * 60 * 60 * 1000;
+type TFn = ReturnType<typeof useI18n>["t"];
+
+export type DropsPlanCardProps = {
+  items: InventoryItem[];
+};
+
+export function DropsPlanCard({ items }: DropsPlanCardProps) {
+  const { t } = useI18n();
+  // Owns its own 60s tick (paused while the window is hidden) so feasibility/
+  // countdowns refresh without any useAppModel plumbing.
+  const now = useVisibleTick(60_000);
+  const plan = React.useMemo(() => buildDropsPlan(items, now), [items, now]);
+  const feasibleCount = plan.filter((e) => e.status === "ok").length;
+
+  return (
+    <Card className="bg-[color:var(--dp-bg-elevated)] border-[color:var(--dp-border)] rounded-[var(--dp-radius-lg)]">
+      <CardHeader className="flex flex-row items-center justify-between border-b border-[color:var(--dp-border-soft)] py-3.5">
+        <CardTitle className="font-mono text-[11px] uppercase tracking-[0.14em] text-[color:var(--dp-text-dim)] font-normal">
+          {t("plan.title")}
+        </CardTitle>
+        {plan.length > 0 && (
+          <span className="font-mono text-[10px] text-[color:var(--dp-text-dimmer)]">
+            {t("plan.feasibleCount", { count: feasibleCount, total: plan.length })}
+          </span>
+        )}
+      </CardHeader>
+      <CardContent className="p-0">
+        {plan.length === 0 ? (
+          <div className="px-5 py-8 text-center font-mono text-[11px] text-[color:var(--dp-text-dimmer)]">
+            {t("plan.empty")}
+          </div>
+        ) : (
+          <ul className="divide-y divide-[color:var(--dp-border-soft)]">
+            {plan.map((entry, idx) => (
+              <PlanRow key={entry.gameKey} entry={entry} rank={idx + 1} now={now} t={t} />
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function PlanRow({ entry, rank, now, t }: { entry: PlanEntry; rank: number; now: number; t: TFn }) {
+  // Representative = the longest open drop (drops are sorted by remaining asc).
+  const rep = entry.drops[entry.drops.length - 1];
+  const pct =
+    rep.requiredMinutes > 0 ? Math.round((rep.earnedMinutes / rep.requiredMinutes) * 100) : 0;
+  const urgent = entry.deadlineMs !== null && entry.deadlineMs - now < URGENT_MS;
+  const lost = entry.status === "lost";
+  const countdown =
+    entry.deadlineMs !== null
+      ? t("plan.endsIn", {
+          time: formatRemaining(Math.max(0, Math.round((entry.deadlineMs - now) / 1000))),
+        })
+      : null;
+
+  return (
+    <li
+      className={cn(
+        "flex items-center gap-3 px-5 py-3",
+        lost && "opacity-50",
+        urgent && !lost && "border-l-2 border-l-[color:var(--dp-signal-err)]",
+      )}
+    >
+      <span className="font-mono text-[11px] tabular-nums text-[color:var(--dp-text-dimmer)]">
+        {String(rank).padStart(2, "0")}
+      </span>
+      <div className="min-w-0 flex-1">
+        <div
+          className={cn("truncate text-[13px] text-[color:var(--dp-text)]", lost && "line-through")}
+        >
+          {entry.gameLabel}
+          <span className="text-[color:var(--dp-text-dimmer)]"> · {rep.title}</span>
+        </div>
+        <div className="mt-1 h-[5px] w-full overflow-hidden rounded-full bg-[color:var(--dp-border)]">
+          <div
+            className="h-full bg-[color:var(--dp-signal-ok)]"
+            style={{ width: `${Math.max(0, Math.min(100, pct))}%` }}
+          />
+        </div>
+      </div>
+      <div className="flex flex-col items-end gap-1">
+        {entry.status === "lost" ? (
+          <Pill tone="err">⚠ {t("plan.lost")}</Pill>
+        ) : entry.status === "partial" ? (
+          <Pill tone="warn">
+            ⚠{" "}
+            {t("plan.atRisk", {
+              count: entry.totalDropCount - entry.feasibleDropCount,
+              total: entry.totalDropCount,
+            })}
+          </Pill>
+        ) : (
+          <Pill tone="ok">
+            ⏳ {t("plan.remaining", { time: formatRemaining(entry.watchMinutes * 60) })}
+          </Pill>
+        )}
+        {countdown && (
+          <span
+            className={cn(
+              "font-mono text-[10px]",
+              urgent ? "text-[color:var(--dp-signal-err)]" : "text-[color:var(--dp-text-dimmer)]",
+            )}
+          >
+            {countdown}
+          </span>
+        )}
+      </div>
+    </li>
+  );
+}

--- a/src/renderer/features/overview/OverviewView.tsx
+++ b/src/renderer/features/overview/OverviewView.tsx
@@ -1,6 +1,7 @@
 import type { ChannelTrackerStatus, ErrorInfo, InventoryState } from "@renderer/shared/types";
 import { HeroPanel } from "./HeroPanel";
 import { QueuePanel } from "./QueuePanel";
+import { DropsPlanCard } from "./DropsPlanCard";
 import { ActivityPanel } from "./ActivityPanel";
 import { EnginePanel } from "./EnginePanel";
 import { AttentionStrip } from "./AttentionStrip";
@@ -106,6 +107,7 @@ export function OverviewView({
           claimStatus={claimStatus}
         />
         <QueuePanel items={items} activeDrop={activeDrop ?? null} targetGame={activeGame} />
+        <DropsPlanCard items={items} />
       </div>
       <div className="flex flex-col gap-4">
         <ActivityPanel />

--- a/src/renderer/features/overview/OverviewView.tsx
+++ b/src/renderer/features/overview/OverviewView.tsx
@@ -9,6 +9,8 @@ import { AttentionStrip } from "./AttentionStrip";
 type OverviewProps = {
   inventory: InventoryState;
   activeGame: string;
+  priorityGames: string[];
+  obeyPriority: boolean;
   activeDropTitle?: string;
   activeDropRemainingMinutes?: number;
   activeDropEta?: number | null;
@@ -50,6 +52,8 @@ type OverviewProps = {
 export function OverviewView({
   inventory,
   activeGame,
+  priorityGames,
+  obeyPriority,
   activeDropTitle,
   activeDropRemainingMinutes,
   activeDropEta,
@@ -107,7 +111,7 @@ export function OverviewView({
           claimStatus={claimStatus}
         />
         <QueuePanel items={items} activeDrop={activeDrop ?? null} targetGame={activeGame} />
-        <DropsPlanCard items={items} />
+        <DropsPlanCard items={items} priorityGames={priorityGames} obeyPriority={obeyPriority} />
       </div>
       <div className="flex flex-col gap-4">
         <ActivityPanel />

--- a/src/renderer/shared/domain/dropsPlanner.test.ts
+++ b/src/renderer/shared/domain/dropsPlanner.test.ts
@@ -135,3 +135,71 @@ describe("buildDropsPlan", () => {
     expect(plan[0].drops.map((d) => d.remainingMinutes)).toEqual([20, 120]);
   });
 });
+
+describe("buildDropsPlan — priority-aware", () => {
+  it("strict mode shows only priority games, in priority order", () => {
+    const plan = buildDropsPlan(
+      [
+        makeItem({ id: "a", game: "Apex", endsAt: iso(60) }),
+        makeItem({ id: "b", game: "Brawl", endsAt: iso(30) }),
+        makeItem({ id: "c", game: "Cult", endsAt: iso(10) }),
+      ],
+      NOW,
+      { priorityGames: ["Brawl", "Apex"], obeyPriority: true },
+    );
+    expect(plan.map((e) => e.gameLabel)).toEqual(["Brawl", "Apex"]);
+    expect(plan.some((e) => e.gameLabel === "Cult")).toBe(false);
+  });
+
+  it("permissive mode lists priority games first, then fallback by EDF", () => {
+    const plan = buildDropsPlan(
+      [
+        makeItem({ id: "p1", game: "P1", endsAt: iso(600) }),
+        makeItem({ id: "f-late", game: "FLate", endsAt: iso(300) }),
+        makeItem({ id: "f-soon", game: "FSoon", endsAt: iso(120) }),
+      ],
+      NOW,
+      { priorityGames: ["P1"], obeyPriority: false },
+    );
+    expect(plan.map((e) => e.gameLabel)).toEqual(["P1", "FSoon", "FLate"]);
+    expect(plan.map((e) => e.isPriority)).toEqual([true, false, false]);
+  });
+
+  it("assigns 1-based priorityRank matched case-insensitively", () => {
+    const plan = buildDropsPlan([makeItem({ game: "Rust" })], NOW, {
+      priorityGames: ["rust"],
+      obeyPriority: false,
+    });
+    expect(plan[0].isPriority).toBe(true);
+    expect(plan[0].priorityRank).toBe(1);
+  });
+
+  it("computes feasibility along priority order (deadline risk), not EDF", () => {
+    const items = [
+      makeItem({ id: "a", game: "A", requiredMinutes: 180, endsAt: iso(10000) }),
+      makeItem({ id: "b", game: "B", requiredMinutes: 60, endsAt: iso(90) }),
+    ];
+    const strict = buildDropsPlan(items, NOW, { priorityGames: ["A", "B"], obeyPriority: true });
+    expect(strict.find((e) => e.gameLabel === "B")?.status).toBe("lost");
+    const edf = buildDropsPlan(items, NOW);
+    expect(edf.find((e) => e.gameLabel === "B")?.status).toBe("ok");
+  });
+
+  it("empty priority list + permissive equals the pure-EDF (no-options) result", () => {
+    const items = [
+      makeItem({ id: "x", game: "X", endsAt: iso(120) }),
+      makeItem({ id: "y", game: "Y", endsAt: iso(60) }),
+    ];
+    expect(buildDropsPlan(items, NOW, { priorityGames: [], obeyPriority: false })).toEqual(
+      buildDropsPlan(items, NOW),
+    );
+  });
+
+  it("empty priority list + strict yields an empty plan", () => {
+    const plan = buildDropsPlan([makeItem({ game: "X", endsAt: iso(60) })], NOW, {
+      priorityGames: [],
+      obeyPriority: true,
+    });
+    expect(plan).toEqual([]);
+  });
+});

--- a/src/renderer/shared/domain/dropsPlanner.test.ts
+++ b/src/renderer/shared/domain/dropsPlanner.test.ts
@@ -28,6 +28,7 @@ describe("buildDropsPlan", () => {
     );
     expect(plan).toHaveLength(1);
     expect(plan[0].totalDropCount).toBe(2);
+    expect(plan[0].gameLabel).toBe("Marvel Rivals");
   });
 
   it("treats parallel tiers as feasible against their own deadlines (regression)", () => {
@@ -109,5 +110,28 @@ describe("buildDropsPlan", () => {
       NOW,
     );
     expect(plan).toEqual([]);
+  });
+
+  it("breaks deadline ties by longest-remaining then game key", () => {
+    const plan = buildDropsPlan(
+      [
+        makeItem({ id: "big", game: "Zebra", requiredMinutes: 120, endsAt: iso(120) }),
+        makeItem({ id: "small", game: "Apex", requiredMinutes: 30, endsAt: iso(120) }),
+      ],
+      NOW,
+    );
+    // Same deadline → shorter remaining (Apex, 30) sorts before longer (Zebra, 120).
+    expect(plan.map((e) => e.gameLabel)).toEqual(["Apex", "Zebra"]);
+  });
+
+  it("orders each game's drops by remaining minutes ascending", () => {
+    const plan = buildDropsPlan(
+      [
+        makeItem({ id: "long", game: "Rust", requiredMinutes: 120 }),
+        makeItem({ id: "short", game: "Rust", requiredMinutes: 20 }),
+      ],
+      NOW,
+    );
+    expect(plan[0].drops.map((d) => d.remainingMinutes)).toEqual([20, 120]);
   });
 });

--- a/src/renderer/shared/domain/dropsPlanner.test.ts
+++ b/src/renderer/shared/domain/dropsPlanner.test.ts
@@ -202,4 +202,27 @@ describe("buildDropsPlan — priority-aware", () => {
     });
     expect(plan).toEqual([]);
   });
+
+  it("a priority game with no plannable drops is absent from the plan (not a lost entry)", () => {
+    const plan = buildDropsPlan([makeItem({ game: "Rust", status: "claimed" })], NOW, {
+      priorityGames: ["Rust"],
+      obeyPriority: true,
+    });
+    expect(plan).toEqual([]);
+  });
+
+  it("permissive: a priority game's cursor debt makes a feasible-under-EDF fallback game lost", () => {
+    const items = [
+      makeItem({ id: "p", game: "Priority", requiredMinutes: 200, endsAt: iso(10000) }),
+      makeItem({ id: "f", game: "Fallback", requiredMinutes: 60, endsAt: iso(240) }),
+    ];
+    // Under pure EDF, Fallback (deadline 240) is farmed first → ok.
+    expect(buildDropsPlan(items, NOW).find((e) => e.gameLabel === "Fallback")?.status).toBe("ok");
+    // Permissive with Priority first: cursor = 200 before Fallback → 200+60 = 260 > 240 → lost.
+    const permissive = buildDropsPlan(items, NOW, {
+      priorityGames: ["Priority"],
+      obeyPriority: false,
+    });
+    expect(permissive.find((e) => e.gameLabel === "Fallback")?.status).toBe("lost");
+  });
 });

--- a/src/renderer/shared/domain/dropsPlanner.test.ts
+++ b/src/renderer/shared/domain/dropsPlanner.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import type { InventoryItem } from "@renderer/shared/types";
+import { buildDropsPlan } from "./dropsPlanner";
+
+const NOW = 1_700_000_000_000;
+const MIN = 60_000;
+const iso = (offsetMinutes: number) => new Date(NOW + offsetMinutes * MIN).toISOString();
+
+const makeItem = (o: Partial<InventoryItem> = {}): InventoryItem => ({
+  id: "d1",
+  game: "Rust",
+  title: "Drop",
+  requiredMinutes: 60,
+  earnedMinutes: 0,
+  status: "progress",
+  ...o,
+});
+
+describe("buildDropsPlan", () => {
+  it("returns [] for empty input", () => {
+    expect(buildDropsPlan([], NOW)).toEqual([]);
+  });
+
+  it("groups differently-cased game names into one entry", () => {
+    const plan = buildDropsPlan(
+      [makeItem({ id: "a", game: "Marvel Rivals" }), makeItem({ id: "b", game: "marvel rivals " })],
+      NOW,
+    );
+    expect(plan).toHaveLength(1);
+    expect(plan[0].totalDropCount).toBe(2);
+  });
+
+  it("treats parallel tiers as feasible against their own deadlines (regression)", () => {
+    const plan = buildDropsPlan(
+      [
+        makeItem({ id: "low", requiredMinutes: 30, endsAt: iso(40) }),
+        makeItem({ id: "high", requiredMinutes: 120, endsAt: iso(60 * 24 * 9) }),
+      ],
+      NOW,
+    );
+    expect(plan).toHaveLength(1);
+    expect(plan[0].status).toBe("ok");
+    expect(plan[0].feasibleDropCount).toBe(2);
+  });
+
+  it("marks a game partial when one tier can't make its deadline", () => {
+    const plan = buildDropsPlan(
+      [
+        makeItem({ id: "doomed", requiredMinutes: 30, endsAt: iso(10) }),
+        makeItem({ id: "fine", requiredMinutes: 60, endsAt: iso(60 * 24 * 5) }),
+      ],
+      NOW,
+    );
+    expect(plan[0].status).toBe("partial");
+    expect(plan[0].feasibleDropCount).toBe(1);
+    expect(plan[0].totalDropCount).toBe(2);
+  });
+
+  it("orders games earliest-deadline-first", () => {
+    const plan = buildDropsPlan(
+      [
+        makeItem({ id: "y", game: "Y", endsAt: iso(180) }),
+        makeItem({ id: "x", game: "X", endsAt: iso(60) }),
+      ],
+      NOW,
+    );
+    expect(plan.map((e) => e.gameLabel)).toEqual(["X", "Y"]);
+  });
+
+  it("sorts games with no deadline last", () => {
+    const plan = buildDropsPlan(
+      [
+        makeItem({ id: "none", game: "NoDeadline", endsAt: undefined }),
+        makeItem({ id: "dated", game: "Dated", endsAt: iso(60) }),
+      ],
+      NOW,
+    );
+    expect(plan.map((e) => e.gameLabel)).toEqual(["Dated", "NoDeadline"]);
+  });
+
+  it("accumulates watch time across games and skips lost ones (skip-not-block)", () => {
+    const plan = buildDropsPlan(
+      [
+        makeItem({ id: "a", game: "A", requiredMinutes: 180, endsAt: iso(240) }),
+        makeItem({ id: "b", game: "B", requiredMinutes: 120, endsAt: iso(270) }),
+        makeItem({ id: "c", game: "C", requiredMinutes: 60, endsAt: iso(360) }),
+      ],
+      NOW,
+    );
+    const byGame = Object.fromEntries(plan.map((e) => [e.gameLabel, e.status]));
+    expect(byGame).toEqual({ A: "ok", B: "lost", C: "ok" });
+  });
+
+  it("treats a malformed endsAt as no deadline (feasible, never NaN)", () => {
+    const plan = buildDropsPlan([makeItem({ endsAt: "not-a-date" })], NOW);
+    expect(plan[0].deadlineMs).toBeNull();
+    expect(plan[0].status).toBe("ok");
+  });
+
+  it("filters out claimed / claimable / excluded / expired / future-start drops", () => {
+    const plan = buildDropsPlan(
+      [
+        makeItem({ id: "claimed", status: "claimed" }),
+        makeItem({ id: "claimable", isClaimable: true }),
+        makeItem({ id: "excluded", excluded: true }),
+        makeItem({ id: "expired", campaignStatus: "EXPIRED" }),
+        makeItem({ id: "future", status: "locked", startsAt: iso(120) }),
+      ],
+      NOW,
+    );
+    expect(plan).toEqual([]);
+  });
+});

--- a/src/renderer/shared/domain/dropsPlanner.ts
+++ b/src/renderer/shared/domain/dropsPlanner.ts
@@ -19,12 +19,21 @@ export type PlanEntry = {
   gameKey: string;
   gameLabel: string;
   watchMinutes: number;
-  deadlineMs: number | null; // earliest tier deadline — EDF sort key + countdown; per-drop feasibility uses each drop's own deadlineMs
+  deadlineMs: number | null; // earliest tier deadline — countdown; per-drop feasibility uses each drop's own deadlineMs
   status: "ok" | "partial" | "lost";
   feasibleDropCount: number;
   totalDropCount: number;
+  isPriority: boolean; // game is on the priority list
+  priorityRank: number | null; // 1-based priority position; null for fallback games
   drops: PlanDrop[];
 };
+
+export type DropsPlanOptions = {
+  priorityGames: string[];
+  obeyPriority: boolean;
+};
+
+const DEFAULT_OPTIONS: DropsPlanOptions = { priorityGames: [], obeyPriority: false };
 
 /** ISO → ms with a finite guard (mirrors InventoryDrop.isExpired parsing). */
 function parseFiniteMs(value: string | undefined): number | null {
@@ -43,7 +52,18 @@ export function isPlannableDrop(item: InventoryItem, now: number): boolean {
   return true;
 }
 
-export function buildDropsPlan(items: InventoryItem[], now: number): PlanEntry[] {
+type Shell = {
+  gameKey: string;
+  gameLabel: string;
+  deadlineMs: number | null;
+  drops: Omit<PlanDrop, "feasible">[];
+};
+
+export function buildDropsPlan(
+  items: InventoryItem[],
+  now: number,
+  options: DropsPlanOptions = DEFAULT_OPTIONS,
+): PlanEntry[] {
   // 1. Filter to plannable drops.
   const plannable = items.filter((it) => isPlannableDrop(it, now));
 
@@ -57,12 +77,6 @@ export function buildDropsPlan(items: InventoryItem[], now: number): PlanEntry[]
   }
 
   // 3. Build per-game shells: drops (sorted by remaining asc) + earliest deadline.
-  type Shell = {
-    gameKey: string;
-    gameLabel: string;
-    deadlineMs: number | null;
-    drops: Omit<PlanDrop, "feasible">[];
-  };
   const shells: Shell[] = [];
   for (const [key, { label, items: groupItems }] of groups) {
     const drops = groupItems
@@ -83,9 +97,16 @@ export function buildDropsPlan(items: InventoryItem[], now: number): PlanEntry[]
     shells.push({ gameKey: key, gameLabel: label, deadlineMs, drops });
   }
 
-  // 4. EDF sort: earliest deadline first (null = +Infinity, last). Tiebreak by the
-  //    binding (longest) drop's remaining, then label, for determinism.
-  shells.sort((a, b) => {
+  // 4. Order by the engine's actual farming order, not pure deadline.
+  //    priorityRankByKey: normalized priority game → 1-based rank (lowest index wins).
+  const priorityRankByKey = new Map<string, number>();
+  options.priorityGames.forEach((game, idx) => {
+    const key = normalizeGameName(game);
+    if (key && !priorityRankByKey.has(key)) priorityRankByKey.set(key, idx + 1);
+  });
+
+  // EDF comparator — used for the fallback tail and the no-priority case.
+  const byEdf = (a: Shell, b: Shell) => {
     const da = a.deadlineMs ?? Number.POSITIVE_INFINITY;
     const db = b.deadlineMs ?? Number.POSITIVE_INFINITY;
     if (da !== db) return da - db;
@@ -93,12 +114,22 @@ export function buildDropsPlan(items: InventoryItem[], now: number): PlanEntry[]
     const wb = Math.max(0, ...b.drops.map((d) => d.remainingMinutes));
     if (wa !== wb) return wa - wb;
     return a.gameKey < b.gameKey ? -1 : a.gameKey > b.gameKey ? 1 : 0;
-  });
+  };
 
-  // 5. Feasibility walk: a cursor of watch-minutes accumulates across games.
+  const priorityShells = shells
+    .filter((s) => priorityRankByKey.has(s.gameKey))
+    .sort((a, b) => priorityRankByKey.get(a.gameKey)! - priorityRankByKey.get(b.gameKey)!);
+  const fallbackShells = shells.filter((s) => !priorityRankByKey.has(s.gameKey)).sort(byEdf);
+
+  // Strict: only priority games. Permissive: priority games, then fallback (EDF).
+  const orderedShells = options.obeyPriority
+    ? priorityShells
+    : [...priorityShells, ...fallbackShells];
+
+  // 5. Feasibility walk along the engine order: a watch-minute cursor accumulates.
   const result: PlanEntry[] = [];
   let cursor = 0;
-  for (const shell of shells) {
+  for (const shell of orderedShells) {
     const cursorStart = cursor;
     const drops: PlanDrop[] = shell.drops.map((d) => {
       const completionMs = now + (cursorStart + d.remainingMinutes) * MINUTE_MS;
@@ -113,6 +144,7 @@ export function buildDropsPlan(items: InventoryItem[], now: number): PlanEntry[]
       : 0;
     const status: PlanEntry["status"] =
       feasibleDrops.length === drops.length ? "ok" : feasibleDrops.length > 0 ? "partial" : "lost";
+    const priorityRank = priorityRankByKey.get(shell.gameKey) ?? null;
     cursor = cursorStart + watchMinutes;
     result.push({
       gameKey: shell.gameKey,
@@ -122,6 +154,8 @@ export function buildDropsPlan(items: InventoryItem[], now: number): PlanEntry[]
       status,
       feasibleDropCount: feasibleDrops.length,
       totalDropCount: drops.length,
+      isPriority: priorityRank !== null,
+      priorityRank,
       drops,
     });
   }

--- a/src/renderer/shared/domain/dropsPlanner.ts
+++ b/src/renderer/shared/domain/dropsPlanner.ts
@@ -1,0 +1,127 @@
+import type { InventoryItem } from "@renderer/shared/types";
+import { canEarnDrop } from "./inventory/inventoryRules";
+import { InventoryDrop } from "./dropDomain";
+import { normalizeGameName } from "./gameName";
+
+const MINUTE_MS = 60_000;
+
+export type PlanDrop = {
+  id: string;
+  title: string;
+  requiredMinutes: number;
+  earnedMinutes: number;
+  remainingMinutes: number;
+  deadlineMs: number | null;
+  feasible: boolean;
+};
+
+export type PlanEntry = {
+  gameKey: string;
+  gameLabel: string;
+  watchMinutes: number;
+  deadlineMs: number | null;
+  status: "ok" | "partial" | "lost";
+  feasibleDropCount: number;
+  totalDropCount: number;
+  drops: PlanDrop[];
+};
+
+/** ISO → ms with a finite guard (mirrors InventoryDrop.isExpired parsing). */
+function parseFiniteMs(value: string | undefined): number | null {
+  if (!value) return null;
+  const ms = Date.parse(value);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+/** A drop is plannable if it can still be earned and is not excluded/expired/future. */
+export function isPlannableDrop(item: InventoryItem, now: number): boolean {
+  if (!canEarnDrop(item, { allowUpcoming: true })) return false;
+  if (item.excluded === true) return false;
+  if (new InventoryDrop(item).isExpired(now)) return false;
+  const startsAtMs = parseFiniteMs(item.startsAt);
+  if (startsAtMs !== null && startsAtMs > now) return false;
+  return true;
+}
+
+export function buildDropsPlan(items: InventoryItem[], now: number): PlanEntry[] {
+  // 1. Filter to plannable drops.
+  const plannable = items.filter((it) => isPlannableDrop(it, now));
+
+  // 2. Group by normalized game name (keep first-seen original casing for display).
+  const groups = new Map<string, { label: string; items: InventoryItem[] }>();
+  for (const it of plannable) {
+    const key = normalizeGameName(it.game);
+    const group = groups.get(key);
+    if (group) group.items.push(it);
+    else groups.set(key, { label: it.game, items: [it] });
+  }
+
+  // 3. Build per-game shells: drops (sorted by remaining asc) + earliest deadline.
+  type Shell = {
+    gameKey: string;
+    gameLabel: string;
+    deadlineMs: number | null;
+    drops: Omit<PlanDrop, "feasible">[];
+  };
+  const shells: Shell[] = [];
+  for (const [key, { label, items: groupItems }] of groups) {
+    const drops = groupItems
+      .map((it) => {
+        const drop = new InventoryDrop(it);
+        return {
+          id: drop.id,
+          title: drop.title,
+          requiredMinutes: drop.requiredMinutes,
+          earnedMinutes: drop.earnedMinutes,
+          remainingMinutes: drop.remainingMinutes,
+          deadlineMs: parseFiniteMs(it.endsAt),
+        };
+      })
+      .sort((a, b) => a.remainingMinutes - b.remainingMinutes);
+    const deadlines = drops.map((d) => d.deadlineMs).filter((v): v is number => v !== null);
+    const deadlineMs = deadlines.length ? Math.min(...deadlines) : null;
+    shells.push({ gameKey: key, gameLabel: label, deadlineMs, drops });
+  }
+
+  // 4. EDF sort: earliest deadline first (null = +Infinity, last). Tiebreak by the
+  //    binding (longest) drop's remaining, then label, for determinism.
+  shells.sort((a, b) => {
+    const da = a.deadlineMs ?? Number.POSITIVE_INFINITY;
+    const db = b.deadlineMs ?? Number.POSITIVE_INFINITY;
+    if (da !== db) return da - db;
+    const wa = Math.max(0, ...a.drops.map((d) => d.remainingMinutes));
+    const wb = Math.max(0, ...b.drops.map((d) => d.remainingMinutes));
+    if (wa !== wb) return wa - wb;
+    return a.gameLabel.localeCompare(b.gameLabel);
+  });
+
+  // 5. Feasibility walk: a cursor of watch-minutes accumulates across games.
+  const result: PlanEntry[] = [];
+  let cursor = 0;
+  for (const shell of shells) {
+    const cursorStart = cursor;
+    const drops: PlanDrop[] = shell.drops.map((d) => {
+      const completionMs = now + (cursorStart + d.remainingMinutes) * MINUTE_MS;
+      const feasible = d.deadlineMs === null || completionMs <= d.deadlineMs;
+      return { ...d, feasible };
+    });
+    const feasibleDrops = drops.filter((d) => d.feasible);
+    const watchMinutes = feasibleDrops.length
+      ? Math.max(...feasibleDrops.map((d) => d.remainingMinutes))
+      : 0;
+    const status: PlanEntry["status"] =
+      feasibleDrops.length === drops.length ? "ok" : feasibleDrops.length > 0 ? "partial" : "lost";
+    cursor = cursorStart + watchMinutes;
+    result.push({
+      gameKey: shell.gameKey,
+      gameLabel: shell.gameLabel,
+      watchMinutes,
+      deadlineMs: shell.deadlineMs,
+      status,
+      feasibleDropCount: feasibleDrops.length,
+      totalDropCount: drops.length,
+      drops,
+    });
+  }
+  return result;
+}

--- a/src/renderer/shared/domain/dropsPlanner.ts
+++ b/src/renderer/shared/domain/dropsPlanner.ts
@@ -19,7 +19,7 @@ export type PlanEntry = {
   gameKey: string;
   gameLabel: string;
   watchMinutes: number;
-  deadlineMs: number | null; // earliest tier deadline — countdown; per-drop feasibility uses each drop's own deadlineMs
+  deadlineMs: number | null; // earliest deadline across the game's open tiers; used for the UI countdown
   status: "ok" | "partial" | "lost";
   feasibleDropCount: number;
   totalDropCount: number;
@@ -29,7 +29,13 @@ export type PlanEntry = {
 };
 
 export type DropsPlanOptions = {
+  /** Games to prioritize, matched case-insensitively. Duplicates use the first occurrence. */
   priorityGames: string[];
+  /**
+   * When true ("strict"), only priority games are planned, so an empty priorityGames
+   * produces an empty plan. When false ("permissive"), priority games are planned first,
+   * followed by the remaining games sorted by EDF.
+   */
   obeyPriority: boolean;
 };
 
@@ -56,6 +62,7 @@ type Shell = {
   gameKey: string;
   gameLabel: string;
   deadlineMs: number | null;
+  maxRemaining: number;
   drops: Omit<PlanDrop, "feasible">[];
 };
 
@@ -94,7 +101,8 @@ export function buildDropsPlan(
       .sort((a, b) => a.remainingMinutes - b.remainingMinutes);
     const deadlines = drops.map((d) => d.deadlineMs).filter((v): v is number => v !== null);
     const deadlineMs = deadlines.length ? Math.min(...deadlines) : null;
-    shells.push({ gameKey: key, gameLabel: label, deadlineMs, drops });
+    const maxRemaining = drops.length ? drops[drops.length - 1].remainingMinutes : 0;
+    shells.push({ gameKey: key, gameLabel: label, deadlineMs, maxRemaining, drops });
   }
 
   // 4. Order by the engine's actual farming order, not pure deadline.
@@ -110,9 +118,7 @@ export function buildDropsPlan(
     const da = a.deadlineMs ?? Number.POSITIVE_INFINITY;
     const db = b.deadlineMs ?? Number.POSITIVE_INFINITY;
     if (da !== db) return da - db;
-    const wa = Math.max(0, ...a.drops.map((d) => d.remainingMinutes));
-    const wb = Math.max(0, ...b.drops.map((d) => d.remainingMinutes));
-    if (wa !== wb) return wa - wb;
+    if (a.maxRemaining !== b.maxRemaining) return a.maxRemaining - b.maxRemaining;
     return a.gameKey < b.gameKey ? -1 : a.gameKey > b.gameKey ? 1 : 0;
   };
 

--- a/src/renderer/shared/domain/dropsPlanner.ts
+++ b/src/renderer/shared/domain/dropsPlanner.ts
@@ -19,7 +19,7 @@ export type PlanEntry = {
   gameKey: string;
   gameLabel: string;
   watchMinutes: number;
-  deadlineMs: number | null;
+  deadlineMs: number | null; // earliest tier deadline — EDF sort key + countdown; per-drop feasibility uses each drop's own deadlineMs
   status: "ok" | "partial" | "lost";
   feasibleDropCount: number;
   totalDropCount: number;
@@ -92,7 +92,7 @@ export function buildDropsPlan(items: InventoryItem[], now: number): PlanEntry[]
     const wa = Math.max(0, ...a.drops.map((d) => d.remainingMinutes));
     const wb = Math.max(0, ...b.drops.map((d) => d.remainingMinutes));
     if (wa !== wb) return wa - wb;
-    return a.gameLabel.localeCompare(b.gameLabel);
+    return a.gameKey < b.gameKey ? -1 : a.gameKey > b.gameKey ? 1 : 0;
   });
 
   // 5. Feasibility walk: a cursor of watch-minutes accumulates across games.
@@ -106,6 +106,8 @@ export function buildDropsPlan(items: InventoryItem[], now: number): PlanEntry[]
       return { ...d, feasible };
     });
     const feasibleDrops = drops.filter((d) => d.feasible);
+    // Minutes actually spent here: max remaining among feasible drops only
+    // (a partial game's lost tiers are excluded; a fully-lost game → 0).
     const watchMinutes = feasibleDrops.length
       ? Math.max(...feasibleDrops.map((d) => d.remainingMinutes))
       : 0;

--- a/src/renderer/shared/hooks/app/useAppModel.ts
+++ b/src/renderer/shared/hooks/app/useAppModel.ts
@@ -570,6 +570,8 @@ export function useAppModel() {
   const statsProps = { stats, resetStats };
   const overviewProps = {
     inventory,
+    priorityGames,
+    obeyPriority,
     activeGame: displayTargetGame,
     activeDropTitle: activeDropInfo?.title,
     activeDropRemainingMinutes: activeDropInfo?.remainingMinutes,

--- a/src/renderer/shared/i18n.tsx
+++ b/src/renderer/shared/i18n.tsx
@@ -897,6 +897,7 @@ const translations: Translations = {
     "plan.feasibleCount": "{count} of {total} fully reachable",
     "plan.atRisk": "{count} of {total} drops won't make it",
     "plan.lost": "won't make it",
+    "plan.fallbackDivider": "then (fallback)",
 
     "queue.manage": "manage →",
     "queue.empty": "no drops in queue",
@@ -1930,6 +1931,7 @@ const translations: Translations = {
     "plan.feasibleCount": "{count} von {total} voll schaffbar",
     "plan.atRisk": "{count} von {total} Drops nicht schaffbar",
     "plan.lost": "nicht schaffbar",
+    "plan.fallbackDivider": "danach (Fallback)",
 
     "queue.manage": "verwalten →",
     "queue.empty": "keine drops in der queue",

--- a/src/renderer/shared/i18n.tsx
+++ b/src/renderer/shared/i18n.tsx
@@ -894,7 +894,7 @@ const translations: Translations = {
     "plan.empty": "No open drops scheduled",
     "plan.remaining": "{time} left",
     "plan.endsIn": "ends in {time}",
-    "plan.feasibleCount": "{count} of {total} reachable",
+    "plan.feasibleCount": "{count} of {total} fully reachable",
     "plan.atRisk": "{count} of {total} drops won't make it",
     "plan.lost": "won't make it",
 
@@ -1927,7 +1927,7 @@ const translations: Translations = {
     "plan.empty": "Keine offenen Drops eingeplant",
     "plan.remaining": "noch {time}",
     "plan.endsIn": "endet in {time}",
-    "plan.feasibleCount": "{count} von {total} schaffbar",
+    "plan.feasibleCount": "{count} von {total} voll schaffbar",
     "plan.atRisk": "{count} von {total} Drops nicht schaffbar",
     "plan.lost": "nicht schaffbar",
 

--- a/src/renderer/shared/i18n.tsx
+++ b/src/renderer/shared/i18n.tsx
@@ -888,6 +888,16 @@ const translations: Translations = {
 
     // queue.* — new namespace, QueuePanel
     "queue.header": "queue · next up",
+
+    // plan.* — Smart Drops Planner
+    "plan.title": "Plan",
+    "plan.empty": "No open drops scheduled",
+    "plan.remaining": "{time} left",
+    "plan.endsIn": "ends in {time}",
+    "plan.feasibleCount": "{count} of {total} reachable",
+    "plan.atRisk": "{count} of {total} drops won't make it",
+    "plan.lost": "won't make it",
+
     "queue.manage": "manage →",
     "queue.empty": "no drops in queue",
     "queue.table.dropGame": "drop · game",
@@ -1911,6 +1921,16 @@ const translations: Translations = {
 
     // queue.* — new namespace, QueuePanel
     "queue.header": "queue · als nächstes",
+
+    // plan.* — Smart Drops Planner
+    "plan.title": "Plan",
+    "plan.empty": "Keine offenen Drops eingeplant",
+    "plan.remaining": "noch {time}",
+    "plan.endsIn": "endet in {time}",
+    "plan.feasibleCount": "{count} von {total} schaffbar",
+    "plan.atRisk": "{count} von {total} Drops nicht schaffbar",
+    "plan.lost": "nicht schaffbar",
+
     "queue.manage": "verwalten →",
     "queue.empty": "keine drops in der queue",
     "queue.table.dropGame": "drop · spiel",


### PR DESCRIPTION
## Summary
- Adds a **Smart Drops Planner** card to the Overview: an advisory, deadline-ordered (EDF) plan of which games to watch and in what order, so the user no longer has to eyeball the inventory and do the "what can I still finish before it expires" math by hand.
- Core logic is a pure, fully-tested `buildDropsPlan(items, now)` in `src/renderer/shared/domain/dropsPlanner.ts`. Feasibility is computed **per drop** (a game's tiers progress in parallel, each against its own deadline), drops are grouped by `normalizeGameName`, games are sorted earliest-deadline-first, and a cumulative watch-minute walk yields an `ok` / `partial` / `lost` status per game (a fully-lost game consumes no time, so later games stay plannable).
- Thin `DropsPlanCard` renders the plan with rank, progress bar, remaining/at-risk pill, deadline countdown, and an urgency accent; it owns a 60s `useVisibleTick` (pauses while the window is hidden). Mounted in the Overview's left column beside `QueuePanel`.
- **No changes** to the watch engine, IPC, preload, or `useAppModel`. New `plan.*` i18n keys added to **both** EN and DE.

## Test Plan
- [x] `npm run typecheck` (both tsconfigs) — clean
- [x] `npm test` — **486/486 pass**, including 11 new `dropsPlanner` tests (EDF ordering, per-drop feasibility regression, partial status, cumulative-cursor skip-not-block, malformed `endsAt`, filtering)
- [x] `npm run format:check` — clean
- [x] `npm run build` — renderer + main/preload build clean
- [ ] Manual: open the Overview and confirm the plan card shows the EDF order, ETA pills, live countdowns, and the ok/partial/lost treatments

## Docs
- Spec: `docs/superpowers/specs/2026-06-13-smart-drops-planner-design.md`
- Plan: `docs/superpowers/plans/2026-06-13-smart-drops-planner.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)