### PR TITLE
feat: Engine Voice — narrate engine status, claim retries, and session expiry

### DIFF
--- a/docs/superpowers/plans/2026-06-13-engine-voice.md
+++ b/docs/superpowers/plans/2026-06-13-engine-voice.md
@@ -1,0 +1,1064 @@
+# Engine Voice Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make DropPilot's autopilot explain itself — live status countdowns, friendly claim-failure narration with a retry timer, and an in-place "session expired → re-login" banner instead of a silent logout.
+
+**Architecture:** Three independent strands, all "pure function + thin component wrapper" (repo convention). No watch-engine behavior change; the only behavior change is the auth fatal path (`logout()` → `markExpired()`). Live time uses the existing `TimeText` leaf (ticks via `useVisibleTick`, isolates the per-second re-render).
+
+**Tech Stack:** React 19 + TypeScript, Vitest (pure functions only — no `@testing-library/react`), Tailwind v4 `--dp-*` tokens, flat i18n dictionaries (en + de).
+
+**Spec:** `docs/superpowers/specs/2026-06-13-engine-voice-design.md`
+
+**Branch:** `feat/engine-voice` (already created off `main`).
+
+**Conventions every task follows:**
+
+- After any code change run `npm run typecheck` (covers BOTH tsconfigs) before committing — `npm run build` does NOT type-check.
+- Run `npx prettier --write <files>` on every touched/created file before committing (CI gates on `format:check`).
+- Add every new i18n key to **both** the English and German blocks of `src/renderer/shared/i18n.tsx`.
+- Commit messages are Conventional Commits and end with the co-author trailer:
+  `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`
+
+---
+
+## File Structure
+
+**Strand 2 — Claim narration + retry**
+
+- Modify `src/renderer/shared/types.ts` — extend `ClaimStatus` error shape.
+- Modify `src/renderer/shared/domain/inventory/inventoryClaimEngine.ts` — populate retry fields on error status.
+- Create `src/renderer/features/overview/claimNarration.ts` — pure `narrateClaim`.
+- Create `src/renderer/features/overview/claimNarration.test.ts` — unit tests.
+- Modify `src/renderer/features/overview/HeroPanel.tsx` — render via `narrateClaim` + `TimeText`.
+- Modify `src/renderer/shared/i18n.tsx` — `hero.claim.retryIn`.
+
+**Strand 1 — Watch-engine live countdowns**
+
+- Modify `src/renderer/shared/hooks/watch/useWatchEngineSnapshot.ts` — expose absolute deadlines.
+- Modify `src/renderer/features/control/ControlView.tsx` — local snapshot type (the duplicate at lines 24-39).
+- Modify `src/renderer/features/control/controlHelpers.ts` — pure `narrateEngineCountdown`.
+- Create `src/renderer/features/control/controlHelpers.test.ts` — unit tests.
+- Modify `src/renderer/features/control/EngineStatusPanel.tsx` — `TimeText` live ticks.
+- Modify `src/renderer/shared/i18n.tsx` — countdown variant keys.
+
+**Strand 3 — Auth `expired` + banner**
+
+- Modify `src/renderer/shared/types.ts` — `AuthState` `expired` variant.
+- Modify `src/renderer/shared/hooks/app/useAuth.ts` — `markExpired()`.
+- Modify `src/renderer/shared/hooks/watch/useWatchingActions.ts` — swap fatal `logout` → `markExpired`.
+- Modify `src/renderer/shared/hooks/app/useAppActions.ts` — thread `markExpired`.
+- Modify `src/renderer/shared/hooks/app/useAppModel.ts` — pass `markExpired` from `useAuth`.
+- Create `src/renderer/features/control/SessionExpiredBanner.tsx` — banner component.
+- Modify `src/renderer/App.tsx` — render the banner in the shell.
+- Modify `src/renderer/shared/i18n.tsx` — `session.expired.*`.
+
+---
+
+## Strand 2 — Claim narration + retry visibility
+
+### Task 1: Extend `ClaimStatus` + populate retry fields
+
+**Files:**
+- Modify: `src/renderer/shared/types.ts:221-227`
+- Modify: `src/renderer/shared/domain/inventory/inventoryClaimEngine.ts:177-184`
+
+- [ ] **Step 1: Extend the `ClaimStatus` type**
+
+In `src/renderer/shared/types.ts`, replace the existing `ClaimStatus` (lines 221-227):
+
+```ts
+export type ClaimStatus = {
+  kind: "success" | "error";
+  message?: string;
+  code?: string;
+  title?: string;
+  at: number;
+  /** Absolute ms; present on an error the engine scheduled a retry for (transient). */
+  nextRetryAt?: number;
+  /** Retry attempt count for the failing drop (1-based). */
+  attempts?: number;
+};
+```
+
+- [ ] **Step 2: Populate the fields in the auto-claim error branch**
+
+In `src/renderer/shared/domain/inventory/inventoryClaimEngine.ts`, the error branch already computes `attempts` and writes the retry map (lines 166-175). Replace the `setClaimStatus` call at lines 177-184:
+
+```ts
+        const errInfo = getClaimErrorInfo(err);
+        deps.setClaimStatus({
+          kind: "error",
+          message: errInfo.message,
+          code: errInfo.code,
+          title: drop.title,
+          at: Date.now(),
+          nextRetryAt: now + getClaimRetryDelay(attempts),
+          attempts,
+        });
+```
+
+(The PubSub-claim error branch at lines 231-238 has no scheduled retry — leave it untouched so it renders as terminal.)
+
+- [ ] **Step 3: Typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS (no errors in either tsconfig).
+
+- [ ] **Step 4: Commit**
+
+```bash
+npx prettier --write src/renderer/shared/types.ts src/renderer/shared/domain/inventory/inventoryClaimEngine.ts
+git add src/renderer/shared/types.ts src/renderer/shared/domain/inventory/inventoryClaimEngine.ts
+git commit -m "feat(engine-voice): carry claim retry timing on ClaimStatus" -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+### Task 2: Pure `narrateClaim` (TDD)
+
+**Files:**
+- Create: `src/renderer/features/overview/claimNarration.ts`
+- Create: `src/renderer/features/overview/claimNarration.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/renderer/features/overview/claimNarration.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { narrateClaim } from "./claimNarration";
+import type { ClaimStatus } from "@renderer/shared/types";
+
+const DICT: Record<string, string> = {
+  "error.claim.failed": "Claim failed",
+  "hero.claim.retryIn": "retry in {time}",
+  "error.unknown": "Something went wrong",
+};
+
+const t = (key: string, vars?: Record<string, string | number>): string => {
+  const template = DICT[key] ?? key;
+  return vars
+    ? template.replace(/\{(\w+)\}/g, (_, name) => String(vars[name] ?? ""))
+    : template;
+};
+
+const NOW = 1_000_000;
+
+describe("narrateClaim", () => {
+  it("returns null when there is no status", () => {
+    expect(narrateClaim(null, NOW, t)).toBeNull();
+    expect(narrateClaim(undefined, NOW, t)).toBeNull();
+  });
+
+  it("renders a success as the ok tone with its message", () => {
+    const status: ClaimStatus = { kind: "success", message: "Auto-claimed: Cap", at: NOW };
+    expect(narrateClaim(status, NOW, t)).toEqual({ tone: "ok", text: "Auto-claimed: Cap" });
+  });
+
+  it("renders a success with no message as null (nothing to say)", () => {
+    const status: ClaimStatus = { kind: "success", at: NOW };
+    expect(narrateClaim(status, NOW, t)).toBeNull();
+  });
+
+  it("renders an auto-retrying error as warn with a localized message and countdown", () => {
+    const status: ClaimStatus = {
+      kind: "error",
+      code: "claim.failed",
+      message: "Drop claim failed",
+      at: NOW,
+      nextRetryAt: NOW + 240_000,
+      attempts: 1,
+    };
+    expect(narrateClaim(status, NOW, t)).toEqual({
+      tone: "warn",
+      text: "Claim failed · retry in 4m",
+    });
+  });
+
+  it("treats an elapsed retry as terminal err (no countdown)", () => {
+    const status: ClaimStatus = {
+      kind: "error",
+      code: "claim.failed",
+      at: NOW,
+      nextRetryAt: NOW - 1,
+      attempts: 3,
+    };
+    expect(narrateClaim(status, NOW, t)).toEqual({ tone: "err", text: "Claim failed" });
+  });
+
+  it("renders an error with no scheduled retry as terminal err", () => {
+    const status: ClaimStatus = { kind: "error", code: "claim.failed", at: NOW };
+    expect(narrateClaim(status, NOW, t)).toEqual({ tone: "err", text: "Claim failed" });
+  });
+
+  it("shows seconds granularity under a minute", () => {
+    const status: ClaimStatus = {
+      kind: "error",
+      code: "claim.failed",
+      at: NOW,
+      nextRetryAt: NOW + 30_000,
+      attempts: 1,
+    };
+    expect(narrateClaim(status, NOW, t)).toEqual({
+      tone: "warn",
+      text: "Claim failed · retry in 30s",
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/renderer/features/overview/claimNarration.test.ts`
+Expected: FAIL — `Failed to resolve import "./claimNarration"`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/renderer/features/overview/claimNarration.ts`:
+
+```ts
+import type { ClaimStatus } from "@renderer/shared/types";
+import { resolveErrorMessage } from "@renderer/shared/utils/errors";
+
+export type Translator = (key: string, vars?: Record<string, string | number>) => string;
+
+export type ClaimNarration = { tone: "ok" | "warn" | "err"; text: string };
+
+/** Compact retry remaining: "4m" once a minute or more out, else "30s". */
+const formatRetryRemaining = (ms: number): string => {
+  if (ms >= 60_000) return `${Math.ceil(ms / 60_000)}m`;
+  return `${Math.ceil(ms / 1000)}s`;
+};
+
+/**
+ * Turn a ClaimStatus into a single narrated line + tone. Pure: pass `now` so the
+ * caller (a TimeText leaf) can re-evaluate the countdown each tick.
+ *
+ * - success            → ok   (its message; null when there is nothing to show)
+ * - error + future retry → warn (localized message + "· retry in 4m") — not scary red
+ * - error otherwise    → err  (terminal)
+ */
+export function narrateClaim(
+  status: ClaimStatus | null | undefined,
+  now: number,
+  t: Translator,
+): ClaimNarration | null {
+  if (!status) return null;
+
+  if (status.kind === "success") {
+    const message = status.message?.trim();
+    return message ? { tone: "ok", text: message } : null;
+  }
+
+  const base = resolveErrorMessage(t, { code: status.code, message: status.message });
+
+  if (typeof status.nextRetryAt === "number" && status.nextRetryAt > now) {
+    const remaining = formatRetryRemaining(status.nextRetryAt - now);
+    return { tone: "warn", text: `${base} · ${t("hero.claim.retryIn", { time: remaining })}` };
+  }
+
+  return { tone: "err", text: base };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run src/renderer/features/overview/claimNarration.test.ts`
+Expected: PASS (7 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+npx prettier --write src/renderer/features/overview/claimNarration.ts src/renderer/features/overview/claimNarration.test.ts
+git add src/renderer/features/overview/claimNarration.ts src/renderer/features/overview/claimNarration.test.ts
+git commit -m "feat(engine-voice): add pure claim narration with retry countdown" -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+### Task 3: Wire `narrateClaim` into HeroPanel + i18n
+
+**Files:**
+- Modify: `src/renderer/features/overview/HeroPanel.tsx` (imports + the `claimStatus` block at lines 200-215)
+- Modify: `src/renderer/shared/i18n.tsx` (after line 899 EN, after line 1934 DE)
+
+- [ ] **Step 1: Add the i18n key (English)**
+
+In `src/renderer/shared/i18n.tsx`, immediately after the English line `"hero.claimFeedback.errorFallback": "Claim failed",` (line 899), add:
+
+```ts
+    "hero.claim.retryIn": "retry in {time}",
+```
+
+- [ ] **Step 2: Add the i18n key (German)**
+
+Immediately after the German line `"hero.claimFeedback.errorFallback": "Claim fehlgeschlagen",` (line 1934), add:
+
+```ts
+    "hero.claim.retryIn": "neuer Versuch in {time}",
+```
+
+- [ ] **Step 3: Import the helper + TimeText in HeroPanel**
+
+In `src/renderer/features/overview/HeroPanel.tsx`, the file already imports `TimeText` (line 9) and `useI18n` (line 7). Add this import next to the other local imports (after line 6 `formatRemainingFromEta`):
+
+```ts
+import { narrateClaim } from "./claimNarration";
+```
+
+- [ ] **Step 4: Replace the claim-status render block**
+
+Replace the existing block at lines 200-215:
+
+```tsx
+        {claimStatus && (
+          <div className="mt-2 font-mono text-[10px]">
+            <TimeText
+              active={claimStatus.kind === "error" && typeof claimStatus.nextRetryAt === "number"}
+              render={(now) => {
+                const narration = narrateClaim(claimStatus, now, t);
+                if (!narration) return null;
+                const toneClass =
+                  narration.tone === "ok"
+                    ? "text-[color:var(--dp-signal-ok)]"
+                    : narration.tone === "warn"
+                      ? "text-[color:var(--dp-signal-warn)]"
+                      : "text-[color:var(--dp-signal-err)]";
+                return <span className={toneClass}>{narration.text}</span>;
+              }}
+            />
+          </div>
+        )}
+```
+
+Note: `claimStatus` prop is typed `{ kind: "success" | "error"; message?: string; code?: string } | null` on `HeroPanelProps` (line 33). Widen it to the shared type so `nextRetryAt`/`code` are available — change line 33 to:
+
+```tsx
+  claimStatus?: import("@renderer/shared/types").ClaimStatus | null;
+```
+
+Also remove the now-unused `cn` import (line 8) — it was only referenced by the old claim block, so `npm run typecheck` flags it otherwise.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 6: Run the full suite**
+
+Run: `npm test`
+Expected: PASS (existing suites green + the new claimNarration tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+npx prettier --write src/renderer/features/overview/HeroPanel.tsx src/renderer/shared/i18n.tsx
+git add src/renderer/features/overview/HeroPanel.tsx src/renderer/shared/i18n.tsx
+git commit -m "feat(engine-voice): narrate claim status with localized text + retry timer" -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Strand 1 — Watch-engine live countdowns
+
+### Task 4: Expose absolute deadlines in the snapshot
+
+**Files:**
+- Modify: `src/renderer/shared/hooks/watch/useWatchEngineSnapshot.ts:79-129`
+- Modify: `src/renderer/features/control/ControlView.tsx:24-39`
+- Modify: `src/renderer/features/control/EngineStatusPanel.tsx:21-31`
+
+- [ ] **Step 1: Add `sinceProgressAt` + `holdUntil` to the snapshot output**
+
+In `src/renderer/shared/hooks/watch/useWatchEngineSnapshot.ts`, update the `noProgressTracker` computation (lines 79-85):
+
+```ts
+    const noProgressTracker =
+      stallTracker && watching
+        ? {
+            recoveryCount: stallTracker.recoveryCount,
+            sinceProgressMs: Math.max(0, now - stallTracker.lastProgressAt),
+            sinceProgressAt: stallTracker.lastProgressAt,
+          }
+        : null;
+```
+
+Then update the returned `suppression` object (lines 115-123) to include the absolute hold deadline:
+
+```ts
+      suppression:
+        suppressionGame && suppressionReason
+          ? {
+              game: suppressionGame,
+              reason: suppressionReason,
+              sinceAt: suppressionAt,
+              holdRemainingMs: suppressionHoldRemainingMs,
+              holdUntil:
+                holdMs && typeof suppressionAt === "number" && Number.isFinite(suppressionAt)
+                  ? suppressionAt + holdMs
+                  : null,
+            }
+          : null,
+```
+
+(`activeCooldowns[].until` is already absolute — no change.)
+
+- [ ] **Step 2: Mirror the fields in ControlView's local snapshot type**
+
+In `src/renderer/features/control/ControlView.tsx`, update the local `WatchEngineSnapshot` type (lines 24-39) — add `holdUntil` to `suppression` and `sinceProgressAt` to `noProgressTracker`:
+
+```ts
+type WatchEngineSnapshot = {
+  decision: WatchEngineDecision;
+  targetGame: string;
+  activeTargetGame: string;
+  suppression: {
+    game: string;
+    reason: WatchEngineSuppressionReason;
+    sinceAt: number | null;
+    holdRemainingMs: number;
+    holdUntil: number | null;
+  } | null;
+  activeCooldowns: Array<{ game: string; until: number; remainingMs: number }>;
+  allowlistActive: boolean;
+  allowlistedLiveChannels: number;
+  totalLiveChannels: number;
+  noProgressTracker: { recoveryCount: number; sinceProgressMs: number; sinceProgressAt: number } | null;
+};
+```
+
+(The `suppression` and `noProgressTracker` objects are already passed wholesale into `<EngineStatusPanel>` at lines 251 & 256, so the new fields flow through automatically.)
+
+- [ ] **Step 3: Mirror the fields in EngineStatusPanel's prop type**
+
+In `src/renderer/features/control/EngineStatusPanel.tsx`, update `EngineStatusPanelProps` (lines 21-31) the same way:
+
+```ts
+  suppression: {
+    game: string;
+    reason: WatchEngineSuppressionReason;
+    sinceAt: number | null;
+    holdRemainingMs: number;
+    holdUntil: number | null;
+  } | null;
+  activeCooldowns: Array<{ game: string; until: number; remainingMs: number }>;
+  allowlistActive: boolean;
+  allowlistedLiveChannels: number;
+  totalLiveChannels: number;
+  noProgressTracker: { recoveryCount: number; sinceProgressMs: number; sinceProgressAt: number } | null;
+```
+
+- [ ] **Step 4: Typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+npx prettier --write src/renderer/shared/hooks/watch/useWatchEngineSnapshot.ts src/renderer/features/control/ControlView.tsx src/renderer/features/control/EngineStatusPanel.tsx
+git add src/renderer/shared/hooks/watch/useWatchEngineSnapshot.ts src/renderer/features/control/ControlView.tsx src/renderer/features/control/EngineStatusPanel.tsx
+git commit -m "feat(engine-voice): expose absolute engine deadlines for live countdowns" -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+### Task 5: Pure `narrateEngineCountdown` (TDD)
+
+**Files:**
+- Modify: `src/renderer/features/control/controlHelpers.ts` (append a new export)
+- Create: `src/renderer/features/control/controlHelpers.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/renderer/features/control/controlHelpers.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { narrateEngineCountdown } from "./controlHelpers";
+
+const DICT: Record<string, string> = {
+  "control.watchEngineNext.suppressedCountdown": "Resuming in {time} after the stall hold.",
+  "control.watchEngineNext.cooldownCountdown":
+    "Cooldown ends in {time}, then auto-select retries.",
+};
+
+const t = (key: string, vars?: Record<string, string | number>): string => {
+  const template = DICT[key] ?? key;
+  return vars
+    ? template.replace(/\{(\w+)\}/g, (_, name) => String(vars[name] ?? ""))
+    : template;
+};
+
+describe("narrateEngineCountdown", () => {
+  it("returns empty when no time remains", () => {
+    expect(narrateEngineCountdown("suppressed", "stall-stop", 0, t)).toBe("");
+    expect(narrateEngineCountdown("cooldown", null, -5, t)).toBe("");
+  });
+
+  it("narrates the stall-stop suppression hold with a live duration", () => {
+    expect(narrateEngineCountdown("suppressed", "stall-stop", 252_000, t)).toBe(
+      "Resuming in 4m 12s after the stall hold.",
+    );
+  });
+
+  it("does not narrate a manual-stop suppression (user must resume)", () => {
+    expect(narrateEngineCountdown("suppressed", "manual-stop", 252_000, t)).toBe("");
+  });
+
+  it("narrates a cooldown countdown", () => {
+    expect(narrateEngineCountdown("cooldown", null, 65_000, t)).toBe(
+      "Cooldown ends in 1m 05s, then auto-select retries.",
+    );
+  });
+
+  it("returns empty for decisions without a countdown", () => {
+    expect(narrateEngineCountdown("watching-progress", null, 99_000, t)).toBe("");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/renderer/features/control/controlHelpers.test.ts`
+Expected: FAIL — `narrateEngineCountdown` is not exported.
+
+- [ ] **Step 3: Add the implementation**
+
+In `src/renderer/features/control/controlHelpers.ts`, add this export directly below `formatDurationMs` (after line 172):
+
+```ts
+/**
+ * Live "Next" line for the two time-bounded engine states. Pure: the caller
+ * (a TimeText leaf) supplies the freshly-ticked remaining ms. Returns "" when
+ * there is no countdown to show, so the caller falls back to the static next.
+ */
+export const narrateEngineCountdown = (
+  decision: WatchEngineDecision,
+  suppressionReason: WatchEngineSuppressionReason | null,
+  remainingMs: number,
+  t: Translator,
+): string => {
+  if (remainingMs <= 0) return "";
+  const time = formatDurationMs(remainingMs);
+  if (decision === "suppressed" && suppressionReason === "stall-stop") {
+    return t("control.watchEngineNext.suppressedCountdown", { time });
+  }
+  if (decision === "cooldown") {
+    return t("control.watchEngineNext.cooldownCountdown", { time });
+  }
+  return "";
+};
+```
+
+(`WatchEngineDecision`, `WatchEngineSuppressionReason`, `Translator`, and `formatDurationMs` are all already defined in this file.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run src/renderer/features/control/controlHelpers.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+npx prettier --write src/renderer/features/control/controlHelpers.ts src/renderer/features/control/controlHelpers.test.ts
+git add src/renderer/features/control/controlHelpers.ts src/renderer/features/control/controlHelpers.test.ts
+git commit -m "feat(engine-voice): add pure engine countdown narration" -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+### Task 6: Live countdowns in EngineStatusPanel + i18n
+
+**Files:**
+- Modify: `src/renderer/shared/i18n.tsx` (after line 312 EN, after line 1336 DE)
+- Modify: `src/renderer/features/control/EngineStatusPanel.tsx`
+
+- [ ] **Step 1: Add the countdown i18n keys (English)**
+
+In `src/renderer/shared/i18n.tsx`, immediately after the English line `"control.watchEngineNext.idleReady": "Auto-select can pick one of the eligible live channels.",` (line 312), add:
+
+```ts
+    "control.watchEngineNext.suppressedCountdown": "Resuming in {time} after the stall hold.",
+    "control.watchEngineNext.cooldownCountdown":
+      "Cooldown ends in {time}, then auto-select retries.",
+```
+
+- [ ] **Step 2: Add the countdown i18n keys (German)**
+
+Immediately after the German line `"control.watchEngineNext.noTarget": "Wähle ein Ziel-Game aus der Liste.",` (line 1336), add:
+
+```ts
+    "control.watchEngineNext.suppressedCountdown": "Fährt in {time} fort, nach dem Stall-Hold.",
+    "control.watchEngineNext.cooldownCountdown":
+      "Cooldown endet in {time}, dann versucht Auto-Select erneut.",
+```
+
+- [ ] **Step 3: Import TimeText + the countdown helper**
+
+In `src/renderer/features/control/EngineStatusPanel.tsx`, add to the imports:
+
+```ts
+import { TimeText } from "@renderer/shared/components/TimeText";
+```
+
+and add `narrateEngineCountdown` to the existing import from `./controlHelpers` (the block at lines 7-15):
+
+```ts
+import {
+  formatDurationMs,
+  mapWatchEngineDecisionDetails,
+  mapWatchEngineDecisionLabel,
+  mapWatchEngineSuppressionReasonLabel,
+  narrateEngineCountdown,
+  watchEngineTone,
+  type WatchEngineDecision,
+  type WatchEngineSuppressionReason,
+} from "./controlHelpers";
+```
+
+- [ ] **Step 4: Make the collapsed "Next" line tick**
+
+Replace the "Next" row (lines 159-164) so the value is a live `TimeText` that prefers the countdown and falls back to the static `details.next`:
+
+```tsx
+          <div className="flex gap-3 font-mono text-[11px]">
+            <span className="text-[color:var(--dp-text-dimmer)] w-12 flex-shrink-0">
+              {t("control.engineStatus.next")}
+            </span>
+            <span className="text-[color:var(--dp-text-dim)] flex-1">
+              <TimeText
+                active={tone === "hold"}
+                render={(now) => {
+                  const remainingMs =
+                    props.decision === "suppressed" && props.suppression?.holdUntil
+                      ? Math.max(0, props.suppression.holdUntil - now)
+                      : props.decision === "cooldown" && props.activeCooldowns[0]
+                        ? Math.max(0, props.activeCooldowns[0].until - now)
+                        : 0;
+                  return (
+                    narrateEngineCountdown(props.decision, suppressionReason, remainingMs, t) ||
+                    details.next
+                  );
+                }}
+              />
+            </span>
+          </div>
+```
+
+(`tone`, `suppressionReason`, and `details` are already computed at the top of the component, lines 53-56. `activeCooldowns` is sorted ascending by `until` in the snapshot, so `[0]` is the soonest.)
+
+- [ ] **Step 5: Make the expanded suppression / cooldown / no-progress rows tick**
+
+First widen `DetailRow` to accept a node value. Replace its signature + the `value` render (lines 195-219) so `value` is a `React.ReactNode`:
+
+```tsx
+function DetailRow({
+  label,
+  value,
+  sub,
+  tone,
+}: {
+  label: string;
+  value: React.ReactNode;
+  sub?: string;
+  tone?: "warn";
+}) {
+```
+
+(The JSX body already renders `{value}` inside the `div`, so no further change there.)
+
+Now feed live `TimeText` nodes into the three time-bearing rows. Replace the suppression detail row (line 174):
+
+```tsx
+          <DetailRow
+            label={t("control.engineStatus.detail.suppression")}
+            value={
+              props.suppression ? (
+                <TimeText
+                  active={props.suppression.holdUntil !== null}
+                  render={(now) => {
+                    const holdRemainingMs =
+                      props.suppression?.holdUntil != null
+                        ? Math.max(0, props.suppression.holdUntil - now)
+                        : 0;
+                    return `${props.suppression!.game} (${mapWatchEngineSuppressionReasonLabel(
+                      props.suppression!.reason,
+                      t,
+                    )})${
+                      holdRemainingMs > 0
+                        ? `, ${t("control.watchEngineHold", {
+                            time: formatDurationMs(holdRemainingMs),
+                          })}`
+                        : ""
+                    }`;
+                  }}
+                />
+              ) : (
+                t("control.watchEngineNoSuppression")
+              )
+            }
+          />
+```
+
+Replace the cooldown detail row (line 175):
+
+```tsx
+          <DetailRow
+            label={t("control.engineStatus.detail.cooldowns")}
+            value={
+              props.activeCooldowns.length > 0 ? (
+                <TimeText
+                  active
+                  render={(now) =>
+                    props.activeCooldowns
+                      .slice(0, 3)
+                      .map((c) => `${c.game} (${formatDurationMs(Math.max(0, c.until - now))})`)
+                      .join(" | ")
+                  }
+                />
+              ) : (
+                t("control.watchEngineNoCooldowns")
+              )
+            }
+          />
+```
+
+Replace the no-progress detail row (lines 182-188) — the row only renders while `noProgressTracker` is non-null (i.e. while watching), so the ticker is always `active`:
+
+```tsx
+          {props.noProgressTracker && (
+            <DetailRow
+              label={t("control.engineStatus.detail.noProgress")}
+              value={
+                <TimeText
+                  active
+                  render={(now) =>
+                    t("control.watchEngineNoProgressValue", {
+                      attempts: props.noProgressTracker!.recoveryCount,
+                      time: formatDurationMs(
+                        Math.max(0, now - props.noProgressTracker!.sinceProgressAt),
+                      ),
+                    })
+                  }
+                />
+              }
+              tone="warn"
+            />
+          )}
+```
+
+Then delete the now-unused `noProgressText` / `suppressionText` / `cooldownText` `const` blocks (lines 65-95) that the rows previously consumed — they are replaced by the inline `TimeText` renders above. Keep `targetText`, `allowlistText`, `channelsText`, `trackerText` (still used).
+
+- [ ] **Step 6: Typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS. (If it flags an unused `formatDurationMs` import — it is still used; if it flags removed consts, ensure no other reference remains.)
+
+- [ ] **Step 7: Run the full suite**
+
+Run: `npm test`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+npx prettier --write src/renderer/features/control/EngineStatusPanel.tsx src/renderer/shared/i18n.tsx
+git add src/renderer/features/control/EngineStatusPanel.tsx src/renderer/shared/i18n.tsx
+git commit -m "feat(engine-voice): live-tick engine status countdowns" -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Strand 3 — Auth `expired` state + re-login banner
+
+### Task 7: `AuthState` `expired` + `useAuth.markExpired`
+
+**Files:**
+- Modify: `src/renderer/shared/types.ts:1-5`
+- Modify: `src/renderer/shared/hooks/app/useAuth.ts`
+
+- [ ] **Step 1: Add the `expired` variant**
+
+In `src/renderer/shared/types.ts`, replace `AuthState` (lines 1-5):
+
+```ts
+export type AuthState =
+  | { status: "idle" }
+  | { status: "pending" }
+  | { status: "ok" }
+  | { status: "expired" }
+  | { status: "error"; message: string };
+```
+
+- [ ] **Step 2: Add `markExpired` to the auth hook**
+
+In `src/renderer/shared/hooks/app/useAuth.ts`, add to the `AuthHook` type (lines 20-24):
+
+```ts
+type AuthHook = {
+  auth: AuthState;
+  startLogin: () => Promise<void>;
+  logout: () => Promise<void>;
+  markExpired: () => Promise<void>;
+};
+```
+
+Add the implementation after `logout` (after line 62), guarding against stomping an in-flight re-login or a repeat fire:
+
+```ts
+  const markExpired = async () => {
+    // Clear the dead token server-side, but keep the dashboard mounted by moving
+    // to a distinct "expired" state instead of "idle". Never stomps an in-flight
+    // re-login (pending) or an already-expired state.
+    await window.electronAPI.auth.logout();
+    setAuth((prev) =>
+      prev.status === "pending" || prev.status === "expired" ? prev : { status: "expired" },
+    );
+  };
+```
+
+And add `markExpired` to the returned object (lines 64-68):
+
+```ts
+  return {
+    auth,
+    startLogin,
+    logout,
+    markExpired,
+  };
+```
+
+Note: `setAuth` from `useState` accepts an updater function — the guard reads the latest state without adding a dependency.
+
+- [ ] **Step 3: Typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS. If `tsc` reports a non-exhaustive `switch (auth.status)` or a `never` assignment anywhere, that site must handle `"expired"` (treat as "not linked"). Fix any such site by adding an `"expired"` case / branch that mirrors `"idle"`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+npx prettier --write src/renderer/shared/types.ts src/renderer/shared/hooks/app/useAuth.ts
+git add src/renderer/shared/types.ts src/renderer/shared/hooks/app/useAuth.ts
+git commit -m "feat(engine-voice): add expired auth state + markExpired" -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+### Task 8: Route the fatal auth path to `markExpired`
+
+**Files:**
+- Modify: `src/renderer/shared/hooks/watch/useWatchingActions.ts` (params + `handleAuthError` line ~122 + deps line 132)
+- Modify: `src/renderer/shared/hooks/app/useAppActions.ts:50,96,116`
+- Modify: `src/renderer/shared/hooks/app/useAppModel.ts:44,318`
+
+- [ ] **Step 1: Swap `logout` → `markExpired` in `useWatchingActions`**
+
+In `src/renderer/shared/hooks/watch/useWatchingActions.ts`:
+
+1. In the params type, replace `logout: () => Promise<void>;` with `markExpired: () => Promise<void>;`.
+2. In the destructure, replace `logout` with `markExpired`.
+3. In `handleAuthError`, replace the fatal-branch call (line ~122) `void logout();` with:
+
+```ts
+        if (fatalRevalidate || shouldLogout) {
+          void markExpired();
+          return;
+        }
+```
+
+4. Update the `useCallback` deps (line 132) from `[isLinked, stopWatching, logout]` to `[isLinked, stopWatching, markExpired]`.
+
+(`markExpired` itself calls the backend `auth.logout()`, so the dead token is still cleared — only the resulting UI state changes from `idle` to `expired`.)
+
+- [ ] **Step 2: Thread `markExpired` through `useAppActions`**
+
+In `src/renderer/shared/hooks/app/useAppActions.ts`:
+
+1. In the `Params` type, replace `logout: () => Promise<void>;` (line 50) with `markExpired: () => Promise<void>;`.
+2. In the destructure (line 96), replace `logout` with `markExpired`.
+3. In the `useWatchingActions({ … })` call (line 116), replace `logout,` with `markExpired,`.
+
+(`logout` is not used elsewhere in this hook — it only ever fed `useWatchingActions`.)
+
+- [ ] **Step 3: Pass `markExpired` from `useAppModel`**
+
+In `src/renderer/shared/hooks/app/useAppModel.ts`:
+
+1. Update the `useAuth` destructure (line 44) from `const { auth, startLogin, logout } = useAuth();` to:
+
+```ts
+  const { auth, startLogin, logout, markExpired } = useAuth();
+```
+
+2. In the `useAppActions({ … })` call, replace `logout,` (line 318) with `markExpired,`.
+
+(`logout` is still used later in `useAppModel` for the intentional Settings logout — leave those references at lines ~590 and ~664 unchanged.)
+
+- [ ] **Step 4: Typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `npm test`
+Expected: PASS. (`useWatchingActions.test.ts` already asserts "requests logout when token is missing/expired" — verify those tests still pass; they exercise the same fatal decision, now via `markExpired`. If a test stubs a `logout` dep by name, update the stub to `markExpired`.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+npx prettier --write src/renderer/shared/hooks/watch/useWatchingActions.ts src/renderer/shared/hooks/app/useAppActions.ts src/renderer/shared/hooks/app/useAppModel.ts
+git add src/renderer/shared/hooks/watch/useWatchingActions.ts src/renderer/shared/hooks/app/useAppActions.ts src/renderer/shared/hooks/app/useAppModel.ts
+git commit -m "feat(engine-voice): route fatal auth errors to expired state, not silent logout" -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+### Task 9: `SessionExpiredBanner` + App wiring + i18n
+
+**Files:**
+- Create: `src/renderer/features/control/SessionExpiredBanner.tsx`
+- Modify: `src/renderer/App.tsx` (import + render after `<AppNav>` line 186)
+- Modify: `src/renderer/shared/i18n.tsx` (after line 86 EN, after line 1125 DE)
+
+- [ ] **Step 1: Add the i18n keys (English)**
+
+In `src/renderer/shared/i18n.tsx`, immediately after the English line `"session.login": "Login...",` (line 86), add:
+
+```ts
+    "session.expired.title": "Session expired — engine paused.",
+    "session.expired.relogin": "Re-login",
+```
+
+- [ ] **Step 2: Add the i18n keys (German)**
+
+Immediately after the German line `"session.login": "Login...",` (line 1125), add:
+
+```ts
+    "session.expired.title": "Sitzung abgelaufen — Engine pausiert.",
+    "session.expired.relogin": "Neu anmelden",
+```
+
+- [ ] **Step 3: Create the banner component**
+
+Create `src/renderer/features/control/SessionExpiredBanner.tsx`:
+
+```tsx
+import * as React from "react";
+import type { AuthState } from "@renderer/shared/types";
+import { Button } from "@renderer/shared/components/ui/button";
+import { useI18n } from "@renderer/shared/i18n";
+
+export type SessionExpiredBannerProps = {
+  auth: AuthState;
+  onRelogin: () => void;
+};
+
+/**
+ * Persistent, non-blocking strip shown only when the session expired. Keeps the
+ * dashboard mounted and offers an in-place re-login instead of the silent bounce
+ * to a signed-out shell.
+ */
+export function SessionExpiredBanner({ auth, onRelogin }: SessionExpiredBannerProps) {
+  const { t } = useI18n();
+  if (auth.status !== "expired") return null;
+
+  return (
+    <div
+      role="status"
+      className="flex items-center justify-between gap-3 border-b border-[color:var(--dp-border)] bg-[color:var(--dp-bg-elevated)] px-5 py-2.5"
+    >
+      <div className="flex items-center gap-2.5 min-w-0">
+        <span
+          aria-hidden="true"
+          className="inline-block h-[6px] w-[6px] flex-shrink-0 rounded-full"
+          style={{ background: "var(--dp-signal-warn)", boxShadow: "0 0 6px rgba(251,191,36,0.5)" }}
+        />
+        <span className="truncate text-[13px] text-[color:var(--dp-text)]">
+          {t("session.expired.title")}
+        </span>
+      </div>
+      <Button variant="dp-primary" size="dp-sm" onClick={onRelogin} className="flex-shrink-0">
+        {t("session.expired.relogin")}
+      </Button>
+    </div>
+  );
+}
+```
+
+(`Button` `dp-primary`/`dp-sm` variants are the same ones used by `App.tsx`'s `sessionRight`. If `Button` does not accept `className`, drop the `className` prop — verify against `src/renderer/shared/components/ui/button.tsx`.)
+
+- [ ] **Step 4: Render the banner in the App shell**
+
+In `src/renderer/App.tsx`, add the import near the other feature imports:
+
+```ts
+import { SessionExpiredBanner } from "./features/control/SessionExpiredBanner";
+```
+
+Then insert the banner between `<AppNav … />` (ends line 186) and the scroll container `<div className="flex-1 min-h-0 overflow-y-auto">` (line 190):
+
+```tsx
+      <AppNav
+        view={navProps.view}
+        onChange={navProps.setView}
+        items={navItems}
+        right={sessionRight}
+      />
+      <SessionExpiredBanner auth={navProps.auth} onRelogin={navProps.startLogin} />
+```
+
+(`navProps.auth` and `navProps.startLogin` are already consumed by `sessionRight` in this file, so they exist on `navProps`.)
+
+- [ ] **Step 5: Typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+npx prettier --write src/renderer/features/control/SessionExpiredBanner.tsx src/renderer/App.tsx src/renderer/shared/i18n.tsx
+git add src/renderer/features/control/SessionExpiredBanner.tsx src/renderer/App.tsx src/renderer/shared/i18n.tsx
+git commit -m "feat(engine-voice): in-place session-expired banner with re-login" -m "Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: Final verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Typecheck both configs**
+
+Run: `npm run typecheck`
+Expected: PASS (renderer + main/preload).
+
+- [ ] **Step 2: Full test suite**
+
+Run: `npm test`
+Expected: PASS — including the new `claimNarration.test.ts` and `controlHelpers.test.ts`.
+
+- [ ] **Step 3: Format gate**
+
+Run: `npm run format:check`
+Expected: PASS (CI gates on this).
+
+- [ ] **Step 4: Production build**
+
+Run: `npm run build`
+Expected: succeeds (renderer `dist/` + `dist-electron/`).
+
+- [ ] **Step 5: Manual smoke (no automated render tests exist)**
+
+Verify by reasoning + a dev run (`npm run dev`) where feasible:
+1. **Claim line** — a failing auto-claim shows amber "<message> · retry in Nm" counting down; a success shows green; the retry text ticks each second.
+2. **Engine status** — while a stall hold or cooldown is active, the collapsed "Next" line counts down live; expanded suppression/cooldown/no-progress rows tick.
+3. **Session expired** — when the fatal auth path fires, the dashboard stays mounted and the warn banner appears with a working **Re-login** that returns to `ok` and resumes; an intentional Settings logout still goes to the signed-out `idle` state (banner absent).
+
+- [ ] **Step 6: Open the PR**
+
+```bash
+git push -u origin feat/engine-voice
+gh pr create --base main --title "feat: Engine Voice — narrate engine status, claim retries, and session expiry" --body "Implements docs/superpowers/specs/2026-06-13-engine-voice-design.md. Live engine-status countdowns, claim narration with localized text + retry timer (transient amber vs terminal red), and an in-place session-expired banner replacing the silent logout. See plan: docs/superpowers/plans/2026-06-13-engine-voice.md."
+```
+
+---
+
+## Notes / risks carried from the spec
+
+- **`expired` vs `idle` audit** — Step 3 of Task 7 relies on `tsc` to surface any exhaustive `switch (auth.status)`; comparison sites (`=== "ok"`, `=== "idle"`) already treat `expired` as "not linked" with no change. Confirm `App.tsx` `linked` and `useAppModel` `isLinkedOrDemo` during Task 9 smoke.
+- **`markExpired` idempotence** — guarded via the `useState` updater (never overwrites `pending`/`expired`).
+- **Live-tick cost** — every ticker is a `TimeText` leaf with `active` scoped to when a countdown is actually live (`tone === "hold"`, an open cooldown, a present hold), so there is no 1 Hz no-op while idle/watching-normally.
+- **Localized claim text** — `narrateClaim` reuses `resolveErrorMessage`, which falls back to the raw `message` then `error.unknown` when a `code` has no key, so no claim path renders blank.

--- a/docs/superpowers/specs/2026-06-13-engine-voice-design.md
+++ b/docs/superpowers/specs/2026-06-13-engine-voice-design.md
@@ -1,0 +1,221 @@
+# Engine Voice — Design
+
+**Date:** 2026-06-13
+**Branch:** `feat/engine-voice` (based on `main` post-#60)
+**Status:** Approved (brainstorming) — plan pending
+
+## Goal
+
+DropPilot runs unattended for hours, but when something goes sideways it speaks in
+machine: the watch engine shows opaque states (`Hold`, `Recover`), claim failures surface
+as a raw English `"Drop claim failed"` with no next step, and an expired session ends in a
+**silent logout** — the user is dropped back to a signed-out shell with no explanation.
+This is the biggest perceived-flakiness gap for a "set-and-forget" tool.
+
+The narration layer is **not greenfield**: `EngineStatusPanel` already maps every watch
+decision to a label + "Why / Next" pair + tone, and localized `error.*` strings exist in
+both locales. The work is to **fill the gaps** in that layer, in place:
+
+1. **Live countdowns** — the engine's hold/cooldown/no-progress timers are static
+   snapshots (`useWatchEngineSnapshot` reads `now` once per memo recompute); make them tick.
+2. **Claim narration + retry visibility** — render the localized friendly text via the
+   `code` the claim engine already sets (today `HeroPanel` ignores it), and surface the
+   already-computed retry backoff as a live "retry in 4m" countdown, with a **transient
+   (amber) vs terminal (red)** distinction so an auto-retrying failure stops looking fatal.
+3. **In-place re-login** — introduce a distinct `expired` auth state so the dashboard
+   stays and a persistent, non-blocking banner offers "Re-login" instead of the silent
+   bounce to signed-out.
+
+No watch-engine **behavior** changes; the only behavior change is the auth fatal path
+(`logout()` → `markExpired()`). Everything else is presentation over state already on
+screen or already computed.
+
+## Decisions (locked during brainstorming)
+
+| Question             | Decision                                                                                                                                                       |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Scope                | **B**: narration polish + retry visibility + in-place re-login. (Not A = narration only; not C = + connection-health banner, which overlaps a separate idea.)  |
+| Narration location   | **In-place (B).** Extend `controlHelpers` for live ticks; small new pure `claimNarration` helper; auth `expired` + banner as a separate concern. No god view-model. |
+| Re-login UX          | **In-place notice via a new `expired` auth state.** Dashboard stays mounted; persistent banner with a Re-login action. Not the "explained signed-out screen".   |
+| Retry surface        | **HeroPanel claim line only** in v1 (single active drop). Not per-row in the inventory list. (YAGNI.)                                                            |
+| Retry plumbing       | **Enrich `ClaimStatus`** with `nextRetryAt` + `attempts` (computed in the error branch already). Do **not** expose the engine's private retry map.              |
+| Voice / tone         | Terse, calm, mono aesthetic. **Transient ≠ terminal**: auto-retrying failures render amber + countdown, not red. Normal lifecycle (offline→switching, already-claimed) is non-alarming. |
+| Connection health    | **Out of scope** (separate "Health Dashboard" idea). The only connection state surfaced here is the auth `expired` banner.                                      |
+
+## Architecture
+
+### Strand 1 — Watch-engine live countdowns
+
+**`src/renderer/shared/hooks/watch/useWatchEngineSnapshot.ts`** — expose absolute deadlines
+alongside the existing relative values (the absolutes are already in hand here):
+
+- `suppression.holdUntil = suppressedAt + holdMs` (currently only `holdRemainingMs` leaks out).
+- `noProgressTracker.sinceProgressAt = stallTracker.lastProgressAt` (currently only `sinceProgressMs`).
+- `activeCooldowns[].until` is already absolute — no change.
+
+The relative fields stay for backward-compat; consumers switch to the absolutes for ticking.
+
+**`src/renderer/features/control/controlHelpers.ts`** — new pure string builders that take a
+duration and return the live "Next" sentence, so the string stays testable and only the
+clock lives in the component:
+
+```ts
+export const narrateSuppressionCountdown: (
+  reason: WatchEngineSuppressionReason,
+  remainingMs: number,
+  t: Translator,
+) => string; // "" when remainingMs <= 0 (hold elapsed → fall back to static next)
+```
+
+`formatDurationMs` is reused verbatim.
+
+**`src/renderer/features/control/EngineStatusPanel.tsx`** — wrap the time-bearing pieces in
+`<TimeText render={(now) => …}>` (already used by `HeroPanel`; ticks via `useVisibleTick`,
+pauses on hidden tab):
+
+- The collapsed **Next** line for `suppressed` / `cooldown` shows the live countdown
+  (`narrateSuppressionCountdown` / cooldown remaining from `until - now`).
+- Expanded **suppression / cooldown / no-progress** rows recompute their durations from the
+  absolute deadlines + ticking `now`.
+
+i18n: add countdown variants of the relevant `control.watchEngineNext.*` keys (en + de).
+
+### Strand 2 — Claim narration + retry visibility
+
+**`src/renderer/shared/types.ts`** — extend `ClaimStatus` error shape:
+
+```ts
+// error variant gains:
+nextRetryAt?: number; // absolute ms; present when the engine scheduled a retry
+attempts?: number;
+```
+
+**`src/renderer/shared/domain/inventory/inventoryClaimEngine.ts`** — at the two
+`setClaimStatus({ kind: "error", … })` sites, include `nextRetryAt: now + getClaimRetryDelay(attempts)`
+and `attempts` (both already computed for the retry-map write just above). PubSub-claim path
+has no scheduled retry → omit the fields there (terminal).
+
+**`src/renderer/features/overview/claimNarration.ts`** (new, pure, tested) —
+
+```ts
+export type ClaimNarration = { tone: "ok" | "warn" | "err"; text: string };
+export function narrateClaim(
+  status: ClaimStatus,
+  now: number,
+  t: Translator,
+): ClaimNarration | null;
+```
+
+Logic:
+
+- `success` → `tone: "ok"`, the success `message` (or `t("hero.claim.autoClaimed", { title })`).
+- `error` **with `code`** → localized `t(toErrorKey(code))` (the existing `error.*` strings)
+  instead of the raw English `message`.
+- `error` with `nextRetryAt > now` → `tone: "warn"`, text + `t("hero.claim.retryIn", { time })`
+  (the `{time}` filled live by the component). This is the "kills the scary red" path.
+- `error` with no pending retry → `tone: "err"` (terminal).
+
+**`src/renderer/features/overview/HeroPanel.tsx`** — replace the inline `claimStatus`
+rendering (lines ~200–215, which ignores `code`) with `narrateClaim`, mapping `tone` to the
+existing `--dp-signal-{ok,warn,err}` colors and filling the retry `{time}` via `TimeText`
+from `nextRetryAt`. The 8s auto-clear in `useAppModel` is unchanged.
+
+i18n: `hero.claim.retryIn`, `hero.claim.autoClaimed` (en + de). (`error.*` keys already exist.)
+
+### Strand 3 — Auth `expired` state + Re-login banner
+
+**`src/renderer/shared/types.ts`** — `AuthState` gains `| { status: "expired" }`.
+
+**`src/renderer/shared/hooks/app/useAuth.ts`** — add `markExpired()`:
+
+```ts
+const markExpired = async () => {
+  await window.electronAPI.auth.logout(); // clear the dead token server-side
+  setAuth({ status: "expired" });
+};
+```
+
+`logout()` (intentional) still resolves to `{ status: "idle" }`. Re-login from `expired`
+reuses the existing `startLogin`. Return `markExpired` from the hook.
+
+**`src/renderer/shared/hooks/watch/useWatchingActions.ts`** — in `handleAuthError`, the
+fatal branch (`fatalRevalidate || shouldLogout`, line ~121) calls `markExpired()` instead of
+`logout()`. `stopWatching()` is unchanged; the transient branch is unchanged. The
+expired-vs-keep decision still lives in the already-tested pure `shouldLogoutForAuthError` —
+no new logic path. Thread `markExpired` in as a dep (mirrors how `logout` is threaded today).
+
+**`src/renderer/shared/hooks/app/useAppModel.ts`** — destructure `markExpired` from `useAuth`
+and pass it into `useWatchingActions` (sibling to `logout`).
+
+**`src/renderer/features/control/SessionExpiredBanner.tsx`** (new) — pure presentational
+component, rendered only when `auth.status === "expired"`:
+
+- Copy: `t("session.expired.title")` ("Session expired — engine paused") + a `[Re-login]`
+  `dp-primary` button wired to `startLogin` (`disabled` while `pending`).
+- `--dp-*` tokens, warn signal accent, non-blocking (a strip, not a modal).
+
+**`src/renderer/App.tsx`** — render `<SessionExpiredBanner>` in the shell between `AppNav`
+and the scrollable content area, so it persists across views. `linked` /`sessionRight`
+already treat any non-`ok` status as "not linked" → the nav Sign-in button stays consistent;
+the banner is the prominent affordance. No blocking connect screen exists, so this composes
+cleanly.
+
+i18n: `session.expired.title`, `session.expired.relogin` (en + de).
+
+## Data flow
+
+```
+Watch engine state change
+  → useWatchEngineSnapshot exposes absolute deadlines (holdUntil / cooldown.until / sinceProgressAt)
+    → EngineStatusPanel <TimeText> ticks → narrateSuppressionCountdown(now) → live "resumes in 3m 12s"
+
+Claim attempt fails (auto-claim)
+  → inventoryClaimEngine schedules retry → setClaimStatus({ error, code, nextRetryAt, attempts })
+    → HeroPanel narrateClaim(status, now) → amber "Claim failed · retry in 4m" (TimeText ticks {time})
+       (terminal failure → red, no countdown; success → green)
+
+Auth fatal (session truly expired)
+  → handleAuthError: stopWatching() + shouldLogoutForAuthError → markExpired()
+    → auth.status = "expired" (dashboard stays mounted)
+      → App.tsx SessionExpiredBanner → [Re-login] → startLogin → status "ok" → engine resumes
+```
+
+## Testing (Vitest, pure functions only — repo convention)
+
+- `claimNarration.test.ts`: success → ok; error+code → localized text (not raw message);
+  error+`nextRetryAt > now` → warn + retry fragment; error, no retry → err (terminal);
+  null/empty status → null.
+- `controlHelpers` countdown helper test: `narrateSuppressionCountdown` returns the right
+  string per reason and remaining ms; empty string once elapsed.
+- Auth: rely on the existing `shouldLogoutForAuthError` tests for the decision; the
+  `logout → markExpired` swap is a thin wiring change (the component/hook glue is not
+  unit-tested per the convention — no `@testing-library/react`).
+
+`npm run typecheck` (both tsconfigs), `npm test`, and `npm run format:check` stay green;
+`prettier --write` on all touched/new files before commit.
+
+## Out of scope (YAGNI)
+
+- Per-row retry countdowns in the inventory list (HeroPanel line only).
+- Connection-health surfacing (PubSub/tracker) — separate "Health Dashboard" idea.
+- A "retry now" button that bypasses the claim backoff (visibility only in v1).
+- Routing the `expired` event to the alert dispatcher (a future small add on the merged
+  alert router).
+
+## Risks
+
+- **Live ticks & re-render cost** — `TimeText` already isolates the per-second re-render to
+  the leaf (it does not re-render the panel/view), so adding several is cheap and matches
+  the existing `HeroPanel` pattern. Verify no `TimeText` ticks while `active` should be false
+  (e.g. no hold pending) to avoid a 1Hz no-op.
+- **`expired` vs `idle` regressions** — every place that branches on `auth.status` must treat
+  `expired` correctly. Audit the `auth.status === "ok"` / `=== "idle"` sites (App.tsx
+  `linked`, `useAppModel` `isLinkedOrDemo`); `expired` must read as "not linked" everywhere
+  except the banner. Caught by `typecheck` (the union is exhaustively matched in a few spots)
+  + manual smoke.
+- **Double-expire / re-login race** — `handleAuthError` can fire repeatedly; `markExpired`
+  must be idempotent (setting `expired` when already `expired` is a no-op) and not stomp a
+  `pending` re-login in progress. Guard: only `markExpired` from non-`pending`/non-`expired`.
+- **Localized claim text accuracy** — switching from the raw `message` to `t(toErrorKey(code))`
+  must cover every `code` the claim path emits (`claim.failed` is the dominant one; all
+  `error.*` keys already exist in both locales). Fallback to `message` when no `code`.

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -9,6 +9,7 @@ import { I18nProvider, useI18n } from "@renderer/shared/i18n";
 import { DevPrimitivesView } from "@renderer/features/dev-primitives";
 import { formatRelative } from "@renderer/features/overview/formatters";
 import { TimeText } from "@renderer/shared/components/TimeText";
+import { SessionExpiredBanner } from "./features/control/SessionExpiredBanner";
 
 function App() {
   const model = useAppModel();
@@ -184,6 +185,7 @@ function AppShell({ model }: { model: Model }) {
         items={navItems}
         right={sessionRight}
       />
+      <SessionExpiredBanner auth={navProps.auth} onRelogin={navProps.startLogin} />
       {/* min-h-0 is critical: flex children default to min-height:auto which
           would prevent the inner content from shrinking below its intrinsic
           height, so overflow-y-auto would never engage. */}

--- a/src/renderer/features/control/ControlView.tsx
+++ b/src/renderer/features/control/ControlView.tsx
@@ -30,12 +30,17 @@ type WatchEngineSnapshot = {
     reason: WatchEngineSuppressionReason;
     sinceAt: number | null;
     holdRemainingMs: number;
+    holdUntil: number | null;
   } | null;
   activeCooldowns: Array<{ game: string; until: number; remainingMs: number }>;
   allowlistActive: boolean;
   allowlistedLiveChannels: number;
   totalLiveChannels: number;
-  noProgressTracker: { recoveryCount: number; sinceProgressMs: number } | null;
+  noProgressTracker: {
+    recoveryCount: number;
+    sinceProgressMs: number;
+    sinceProgressAt: number;
+  } | null;
 };
 
 type ControlProps = {

--- a/src/renderer/features/control/ControlView.tsx
+++ b/src/renderer/features/control/ControlView.tsx
@@ -29,7 +29,6 @@ type WatchEngineSnapshot = {
     game: string;
     reason: WatchEngineSuppressionReason;
     sinceAt: number | null;
-    holdRemainingMs: number;
     holdUntil: number | null;
   } | null;
   activeCooldowns: Array<{ game: string; until: number; remainingMs: number }>;
@@ -38,7 +37,6 @@ type WatchEngineSnapshot = {
   totalLiveChannels: number;
   noProgressTracker: {
     recoveryCount: number;
-    sinceProgressMs: number;
     sinceProgressAt: number;
   } | null;
 };

--- a/src/renderer/features/control/EngineStatusPanel.tsx
+++ b/src/renderer/features/control/EngineStatusPanel.tsx
@@ -144,7 +144,10 @@ export function EngineStatusPanel(props: EngineStatusPanelProps) {
             </span>
             <span className="text-[color:var(--dp-text-dim)] flex-1">
               <TimeText
-                active={tone === "hold"}
+                active={
+                  tone === "hold" &&
+                  (props.decision === "cooldown" || suppressionReason === "stall-stop")
+                }
                 render={(now) => {
                   const remainingMs =
                     props.decision === "suppressed" && props.suppression?.holdUntil

--- a/src/renderer/features/control/EngineStatusPanel.tsx
+++ b/src/renderer/features/control/EngineStatusPanel.tsx
@@ -24,7 +24,6 @@ export type EngineStatusPanelProps = {
     game: string;
     reason: WatchEngineSuppressionReason;
     sinceAt: number | null;
-    holdRemainingMs: number;
     holdUntil: number | null;
   } | null;
   activeCooldowns: Array<{ game: string; until: number; remainingMs: number }>;
@@ -33,7 +32,6 @@ export type EngineStatusPanelProps = {
   totalLiveChannels: number;
   noProgressTracker: {
     recoveryCount: number;
-    sinceProgressMs: number;
     sinceProgressAt: number;
   } | null;
   trackerStatus?: ChannelTrackerStatus | null;

--- a/src/renderer/features/control/EngineStatusPanel.tsx
+++ b/src/renderer/features/control/EngineStatusPanel.tsx
@@ -23,12 +23,17 @@ export type EngineStatusPanelProps = {
     reason: WatchEngineSuppressionReason;
     sinceAt: number | null;
     holdRemainingMs: number;
+    holdUntil: number | null;
   } | null;
   activeCooldowns: Array<{ game: string; until: number; remainingMs: number }>;
   allowlistActive: boolean;
   allowlistedLiveChannels: number;
   totalLiveChannels: number;
-  noProgressTracker: { recoveryCount: number; sinceProgressMs: number } | null;
+  noProgressTracker: {
+    recoveryCount: number;
+    sinceProgressMs: number;
+    sinceProgressAt: number;
+  } | null;
   trackerStatus?: ChannelTrackerStatus | null;
 };
 

--- a/src/renderer/features/control/EngineStatusPanel.tsx
+++ b/src/renderer/features/control/EngineStatusPanel.tsx
@@ -4,11 +4,13 @@ import { ChevronDown } from "@renderer/shared/lib/icons";
 import { cn } from "@renderer/shared/lib/utils";
 import { useI18n } from "@renderer/shared/i18n";
 import type { ChannelTrackerStatus } from "@renderer/shared/types";
+import { TimeText } from "@renderer/shared/components/TimeText";
 import {
   formatDurationMs,
   mapWatchEngineDecisionDetails,
   mapWatchEngineDecisionLabel,
   mapWatchEngineSuppressionReasonLabel,
+  narrateEngineCountdown,
   watchEngineTone,
   type WatchEngineDecision,
   type WatchEngineSuppressionReason,
@@ -67,22 +69,6 @@ export function EngineStatusPanel(props: EngineStatusPanelProps) {
       : props.activeTargetGame) ||
     t("control.noTarget");
 
-  const suppressionText = props.suppression
-    ? `${props.suppression.game} (${mapWatchEngineSuppressionReasonLabel(props.suppression.reason, t)})${
-        props.suppression.holdRemainingMs > 0
-          ? `, ${t("control.watchEngineHold", { time: formatDurationMs(props.suppression.holdRemainingMs) })}`
-          : ""
-      }`
-    : t("control.watchEngineNoSuppression");
-
-  const cooldownText =
-    props.activeCooldowns.length > 0
-      ? props.activeCooldowns
-          .slice(0, 3)
-          .map((c) => `${c.game} (${formatDurationMs(c.remainingMs)})`)
-          .join(" | ")
-      : t("control.watchEngineNoCooldowns");
-
   const allowlistText = props.allowlistActive
     ? t("control.watchEngineAllowlistOn")
     : t("control.watchEngineAllowlistOff");
@@ -91,13 +77,6 @@ export function EngineStatusPanel(props: EngineStatusPanelProps) {
     eligible: props.allowlistedLiveChannels,
     total: props.totalLiveChannels,
   });
-
-  const noProgressText = props.noProgressTracker
-    ? t("control.watchEngineNoProgressValue", {
-        attempts: props.noProgressTracker.recoveryCount,
-        time: formatDurationMs(props.noProgressTracker.sinceProgressMs),
-      })
-    : null;
 
   const trackerTone: "warn" | undefined = props.trackerStatus?.fallbackActive ? "warn" : undefined;
   const trackerText = (() => {
@@ -165,7 +144,23 @@ export function EngineStatusPanel(props: EngineStatusPanelProps) {
             <span className="text-[color:var(--dp-text-dimmer)] w-12 flex-shrink-0">
               {t("control.engineStatus.next")}
             </span>
-            <span className="text-[color:var(--dp-text-dim)] flex-1">{details.next}</span>
+            <span className="text-[color:var(--dp-text-dim)] flex-1">
+              <TimeText
+                active={tone === "hold"}
+                render={(now) => {
+                  const remainingMs =
+                    props.decision === "suppressed" && props.suppression?.holdUntil
+                      ? Math.max(0, props.suppression.holdUntil - now)
+                      : props.decision === "cooldown" && props.activeCooldowns[0]
+                        ? Math.max(0, props.activeCooldowns[0].until - now)
+                        : 0;
+                  return (
+                    narrateEngineCountdown(props.decision, suppressionReason, remainingMs, t) ||
+                    details.next
+                  );
+                }}
+              />
+            </span>
           </div>
         </div>
       </div>
@@ -176,18 +171,74 @@ export function EngineStatusPanel(props: EngineStatusPanelProps) {
           className="border-t border-[color:var(--dp-border-soft)] px-5 py-4 grid gap-2"
         >
           <DetailRow label={t("control.engineStatus.detail.target")} value={targetText} />
-          <DetailRow label={t("control.engineStatus.detail.suppression")} value={suppressionText} />
-          <DetailRow label={t("control.engineStatus.detail.cooldowns")} value={cooldownText} />
+          <DetailRow
+            label={t("control.engineStatus.detail.suppression")}
+            value={
+              props.suppression ? (
+                <TimeText
+                  active={props.suppression.holdUntil !== null}
+                  render={(now) => {
+                    const holdRemainingMs =
+                      props.suppression?.holdUntil != null
+                        ? Math.max(0, props.suppression.holdUntil - now)
+                        : 0;
+                    return `${props.suppression!.game} (${mapWatchEngineSuppressionReasonLabel(
+                      props.suppression!.reason,
+                      t,
+                    )})${
+                      holdRemainingMs > 0
+                        ? `, ${t("control.watchEngineHold", {
+                            time: formatDurationMs(holdRemainingMs),
+                          })}`
+                        : ""
+                    }`;
+                  }}
+                />
+              ) : (
+                t("control.watchEngineNoSuppression")
+              )
+            }
+          />
+          <DetailRow
+            label={t("control.engineStatus.detail.cooldowns")}
+            value={
+              props.activeCooldowns.length > 0 ? (
+                <TimeText
+                  active
+                  render={(now) =>
+                    props.activeCooldowns
+                      .slice(0, 3)
+                      .map((c) => `${c.game} (${formatDurationMs(Math.max(0, c.until - now))})`)
+                      .join(" | ")
+                  }
+                />
+              ) : (
+                t("control.watchEngineNoCooldowns")
+              )
+            }
+          />
           <DetailRow
             label={t("control.engineStatus.detail.allowlist")}
             value={allowlistText}
             sub={channelsText}
           />
           <DetailRow label={t("control.tracker.label")} value={trackerText} tone={trackerTone} />
-          {noProgressText && (
+          {props.noProgressTracker && (
             <DetailRow
               label={t("control.engineStatus.detail.noProgress")}
-              value={noProgressText}
+              value={
+                <TimeText
+                  active
+                  render={(now) =>
+                    t("control.watchEngineNoProgressValue", {
+                      attempts: props.noProgressTracker!.recoveryCount,
+                      time: formatDurationMs(
+                        Math.max(0, now - props.noProgressTracker!.sinceProgressAt),
+                      ),
+                    })
+                  }
+                />
+              }
               tone="warn"
             />
           )}
@@ -204,7 +255,7 @@ function DetailRow({
   tone,
 }: {
   label: string;
-  value: string;
+  value: React.ReactNode;
   sub?: string;
   tone?: "warn";
 }) {

--- a/src/renderer/features/control/SessionExpiredBanner.tsx
+++ b/src/renderer/features/control/SessionExpiredBanner.tsx
@@ -1,0 +1,40 @@
+import * as React from "react";
+import type { AuthState } from "@renderer/shared/types";
+import { Button } from "@renderer/shared/components/ui/button";
+import { useI18n } from "@renderer/shared/i18n";
+
+export type SessionExpiredBannerProps = {
+  auth: AuthState;
+  onRelogin: () => void;
+};
+
+/**
+ * Persistent, non-blocking strip shown only when the session expired. Keeps the
+ * dashboard mounted and offers an in-place re-login instead of the silent bounce
+ * to a signed-out shell.
+ */
+export function SessionExpiredBanner({ auth, onRelogin }: SessionExpiredBannerProps) {
+  const { t } = useI18n();
+  if (auth.status !== "expired") return null;
+
+  return (
+    <div
+      role="status"
+      className="flex items-center justify-between gap-3 border-b border-[color:var(--dp-border)] bg-[color:var(--dp-bg-elevated)] px-5 py-2.5"
+    >
+      <div className="flex items-center gap-2.5 min-w-0">
+        <span
+          aria-hidden="true"
+          className="inline-block h-[6px] w-[6px] flex-shrink-0 rounded-full"
+          style={{ background: "var(--dp-signal-warn)", boxShadow: "0 0 6px rgba(251,191,36,0.5)" }}
+        />
+        <span className="truncate text-[13px] text-[color:var(--dp-text)]">
+          {t("session.expired.title")}
+        </span>
+      </div>
+      <Button variant="dp-primary" size="dp-sm" onClick={onRelogin} className="flex-shrink-0">
+        {t("session.expired.relogin")}
+      </Button>
+    </div>
+  );
+}

--- a/src/renderer/features/control/controlHelpers.test.ts
+++ b/src/renderer/features/control/controlHelpers.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { narrateEngineCountdown } from "./controlHelpers";
+
+const DICT: Record<string, string> = {
+  "control.watchEngineNext.suppressedCountdown": "Resuming in {time} after the stall hold.",
+  "control.watchEngineNext.cooldownCountdown": "Cooldown ends in {time}, then auto-select retries.",
+};
+
+const t = (key: string, vars?: Record<string, string | number>): string => {
+  const template = DICT[key] ?? key;
+  return vars ? template.replace(/\{(\w+)\}/g, (_, name) => String(vars[name] ?? "")) : template;
+};
+
+describe("narrateEngineCountdown", () => {
+  it("returns empty when no time remains", () => {
+    expect(narrateEngineCountdown("suppressed", "stall-stop", 0, t)).toBe("");
+    expect(narrateEngineCountdown("cooldown", null, -5, t)).toBe("");
+  });
+
+  it("narrates the stall-stop suppression hold with a live duration", () => {
+    expect(narrateEngineCountdown("suppressed", "stall-stop", 252_000, t)).toBe(
+      "Resuming in 4m 12s after the stall hold.",
+    );
+  });
+
+  it("does not narrate a manual-stop suppression (user must resume)", () => {
+    expect(narrateEngineCountdown("suppressed", "manual-stop", 252_000, t)).toBe("");
+  });
+
+  it("narrates a cooldown countdown", () => {
+    expect(narrateEngineCountdown("cooldown", null, 65_000, t)).toBe(
+      "Cooldown ends in 1m 05s, then auto-select retries.",
+    );
+  });
+
+  it("returns empty for decisions without a countdown", () => {
+    expect(narrateEngineCountdown("watching-progress", null, 99_000, t)).toBe("");
+  });
+});

--- a/src/renderer/features/control/controlHelpers.ts
+++ b/src/renderer/features/control/controlHelpers.ts
@@ -171,6 +171,28 @@ export const formatDurationMs = (ms: number): string => {
   return `${minutes}m ${seconds.toString().padStart(2, "0")}s`;
 };
 
+/**
+ * Live "Next" line for the two time-bounded engine states. Pure: the caller
+ * (a TimeText leaf) supplies the freshly-ticked remaining ms. Returns "" when
+ * there is no countdown to show, so the caller falls back to the static next.
+ */
+export const narrateEngineCountdown = (
+  decision: WatchEngineDecision,
+  suppressionReason: WatchEngineSuppressionReason | null,
+  remainingMs: number,
+  t: Translator,
+): string => {
+  if (remainingMs <= 0) return "";
+  const time = formatDurationMs(remainingMs);
+  if (decision === "suppressed" && suppressionReason === "stall-stop") {
+    return t("control.watchEngineNext.suppressedCountdown", { time });
+  }
+  if (decision === "cooldown") {
+    return t("control.watchEngineNext.cooldownCountdown", { time });
+  }
+  return "";
+};
+
 /** Blocking reason helpers (preserved from ControlView). */
 export const formatBlockingReason = (reason: string | undefined, t: Translator): string => {
   if (!reason) return t("inventory.blockReason.unknown");

--- a/src/renderer/features/overview/HeroPanel.tsx
+++ b/src/renderer/features/overview/HeroPanel.tsx
@@ -7,6 +7,7 @@ import { formatRemainingFromEta } from "./formatters";
 import { narrateClaim } from "./claimNarration";
 import { useI18n } from "@renderer/shared/i18n";
 import { TimeText } from "@renderer/shared/components/TimeText";
+import type { ClaimStatus } from "@renderer/shared/types";
 
 export type HeroPanelProps = {
   activeGame?: string;
@@ -30,7 +31,7 @@ export type HeroPanelProps = {
   /** Navigate to Priorities (Phase 5 wiring). When null/undefined, switch button stays disabled. */
   onSwitchTarget?: () => void;
   onClaimNow?: () => void | Promise<void>;
-  claimStatus?: import("@renderer/shared/types").ClaimStatus | null;
+  claimStatus?: ClaimStatus | null;
 };
 
 export function HeroPanel({

--- a/src/renderer/features/overview/HeroPanel.tsx
+++ b/src/renderer/features/overview/HeroPanel.tsx
@@ -4,8 +4,8 @@ import { Button } from "@renderer/shared/components/ui/button";
 import { SectionLabel } from "@renderer/shared/components/ui/section-label";
 import { Check, Pause, RotateCw } from "@renderer/shared/lib/icons";
 import { formatRemainingFromEta } from "./formatters";
+import { narrateClaim } from "./claimNarration";
 import { useI18n } from "@renderer/shared/i18n";
-import { cn } from "@renderer/shared/lib/utils";
 import { TimeText } from "@renderer/shared/components/TimeText";
 
 export type HeroPanelProps = {
@@ -30,7 +30,7 @@ export type HeroPanelProps = {
   /** Navigate to Priorities (Phase 5 wiring). When null/undefined, switch button stays disabled. */
   onSwitchTarget?: () => void;
   onClaimNow?: () => void | Promise<void>;
-  claimStatus?: { kind: "success" | "error"; message?: string; code?: string } | null;
+  claimStatus?: import("@renderer/shared/types").ClaimStatus | null;
 };
 
 export function HeroPanel({
@@ -198,19 +198,21 @@ export function HeroPanel({
           </Button>
         </div>
         {claimStatus && (
-          <div
-            className={cn(
-              "mt-2 font-mono text-[10px]",
-              claimStatus.kind === "success"
-                ? "text-[color:var(--dp-signal-ok)]"
-                : "text-[color:var(--dp-signal-err)]",
-            )}
-          >
-            {claimStatus.kind === "success" && claimStatus.message
-              ? claimStatus.message
-              : claimStatus.kind === "error"
-                ? (claimStatus.message ?? t("hero.claimFeedback.errorFallback"))
-                : null}
+          <div className="mt-2 font-mono text-[10px]">
+            <TimeText
+              active={claimStatus.kind === "error" && typeof claimStatus.nextRetryAt === "number"}
+              render={(now) => {
+                const narration = narrateClaim(claimStatus, now, t);
+                if (!narration) return null;
+                const toneClass =
+                  narration.tone === "ok"
+                    ? "text-[color:var(--dp-signal-ok)]"
+                    : narration.tone === "warn"
+                      ? "text-[color:var(--dp-signal-warn)]"
+                      : "text-[color:var(--dp-signal-err)]";
+                return <span className={toneClass}>{narration.text}</span>;
+              }}
+            />
           </div>
         )}
       </div>

--- a/src/renderer/features/overview/OverviewView.tsx
+++ b/src/renderer/features/overview/OverviewView.tsx
@@ -1,4 +1,4 @@
-import type { ErrorInfo, InventoryState } from "@renderer/shared/types";
+import type { ClaimStatus, ErrorInfo, InventoryState } from "@renderer/shared/types";
 import { HeroPanel } from "./HeroPanel";
 import { QueuePanel } from "./QueuePanel";
 import { ActivityPanel } from "./ActivityPanel";
@@ -40,7 +40,7 @@ type OverviewProps = {
   onPause?: () => void;
   onSwitchTarget?: () => void;
   onClaimNow?: () => void | Promise<void>;
-  claimStatus?: { kind: "success" | "error"; message?: string; code?: string } | null;
+  claimStatus?: ClaimStatus | null;
   refreshMinMs?: number;
   refreshMaxMs?: number;
 };

--- a/src/renderer/features/overview/claimNarration.test.ts
+++ b/src/renderer/features/overview/claimNarration.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { narrateClaim } from "./claimNarration";
+import type { ClaimStatus } from "@renderer/shared/types";
+
+const DICT: Record<string, string> = {
+  "error.claim.failed": "Claim failed",
+  "hero.claim.retryIn": "retry in {time}",
+  "error.unknown": "Something went wrong",
+};
+
+const t = (key: string, vars?: Record<string, string | number>): string => {
+  const template = DICT[key] ?? key;
+  return vars ? template.replace(/\{(\w+)\}/g, (_, name) => String(vars[name] ?? "")) : template;
+};
+
+const NOW = 1_000_000;
+
+describe("narrateClaim", () => {
+  it("returns null when there is no status", () => {
+    expect(narrateClaim(null, NOW, t)).toBeNull();
+    expect(narrateClaim(undefined, NOW, t)).toBeNull();
+  });
+
+  it("renders a success as the ok tone with its message", () => {
+    const status: ClaimStatus = { kind: "success", message: "Auto-claimed: Cap", at: NOW };
+    expect(narrateClaim(status, NOW, t)).toEqual({ tone: "ok", text: "Auto-claimed: Cap" });
+  });
+
+  it("renders a success with no message as null (nothing to say)", () => {
+    const status: ClaimStatus = { kind: "success", at: NOW };
+    expect(narrateClaim(status, NOW, t)).toBeNull();
+  });
+
+  it("renders an auto-retrying error as warn with a localized message and countdown", () => {
+    const status: ClaimStatus = {
+      kind: "error",
+      code: "claim.failed",
+      message: "Drop claim failed",
+      at: NOW,
+      nextRetryAt: NOW + 240_000,
+      attempts: 1,
+    };
+    expect(narrateClaim(status, NOW, t)).toEqual({
+      tone: "warn",
+      text: "Claim failed · retry in 4m",
+    });
+  });
+
+  it("treats an elapsed retry as terminal err (no countdown)", () => {
+    const status: ClaimStatus = {
+      kind: "error",
+      code: "claim.failed",
+      at: NOW,
+      nextRetryAt: NOW - 1,
+      attempts: 3,
+    };
+    expect(narrateClaim(status, NOW, t)).toEqual({ tone: "err", text: "Claim failed" });
+  });
+
+  it("renders an error with no scheduled retry as terminal err", () => {
+    const status: ClaimStatus = { kind: "error", code: "claim.failed", at: NOW };
+    expect(narrateClaim(status, NOW, t)).toEqual({ tone: "err", text: "Claim failed" });
+  });
+
+  it("shows seconds granularity under a minute", () => {
+    const status: ClaimStatus = {
+      kind: "error",
+      code: "claim.failed",
+      at: NOW,
+      nextRetryAt: NOW + 30_000,
+      attempts: 1,
+    };
+    expect(narrateClaim(status, NOW, t)).toEqual({
+      tone: "warn",
+      text: "Claim failed · retry in 30s",
+    });
+  });
+});

--- a/src/renderer/features/overview/claimNarration.ts
+++ b/src/renderer/features/overview/claimNarration.ts
@@ -1,0 +1,42 @@
+import type { ClaimStatus } from "@renderer/shared/types";
+import { resolveErrorMessage } from "@renderer/shared/utils/errors";
+
+export type Translator = (key: string, vars?: Record<string, string | number>) => string;
+
+export type ClaimNarration = { tone: "ok" | "warn" | "err"; text: string };
+
+/** Compact retry remaining: "4m" once a minute or more out, else "30s". */
+const formatRetryRemaining = (ms: number): string => {
+  if (ms >= 60_000) return `${Math.ceil(ms / 60_000)}m`;
+  return `${Math.ceil(ms / 1000)}s`;
+};
+
+/**
+ * Turn a ClaimStatus into a single narrated line + tone. Pure: pass `now` so the
+ * caller (a TimeText leaf) can re-evaluate the countdown each tick.
+ *
+ * - success            → ok   (its message; null when there is nothing to show)
+ * - error + future retry → warn (localized message + "· retry in 4m") — not scary red
+ * - error otherwise    → err  (terminal)
+ */
+export function narrateClaim(
+  status: ClaimStatus | null | undefined,
+  now: number,
+  t: Translator,
+): ClaimNarration | null {
+  if (!status) return null;
+
+  if (status.kind === "success") {
+    const message = status.message?.trim();
+    return message ? { tone: "ok", text: message } : null;
+  }
+
+  const base = resolveErrorMessage(t, { code: status.code, message: status.message });
+
+  if (typeof status.nextRetryAt === "number" && status.nextRetryAt > now) {
+    const remaining = formatRetryRemaining(status.nextRetryAt - now);
+    return { tone: "warn", text: `${base} · ${t("hero.claim.retryIn", { time: remaining })}` };
+  }
+
+  return { tone: "err", text: base };
+}

--- a/src/renderer/shared/domain/inventory/inventoryClaimEngine.ts
+++ b/src/renderer/shared/domain/inventory/inventoryClaimEngine.ts
@@ -181,6 +181,8 @@ export class InventoryClaimEngine {
           code: errInfo.code,
           title: drop.title,
           at: Date.now(),
+          nextRetryAt: now + getClaimRetryDelay(attempts),
+          attempts,
         });
       }
     }

--- a/src/renderer/shared/hooks/app/useAppActions.ts
+++ b/src/renderer/shared/hooks/app/useAppActions.ts
@@ -47,7 +47,7 @@ type Params = {
   setAutoSelectEnabled: (next: boolean) => void;
   fetchInventory: (opts?: { forceLoading?: boolean }) => Promise<void>;
   isLinked: boolean;
-  logout: () => Promise<void>;
+  markExpired: () => Promise<void>;
   onManualStartWatching?: (channel: ChannelEntry) => void;
   setUpdateStatus: Dispatch<SetStateAction<AppUpdateStatus>>;
   setFilter: (next: FilterKey) => void;
@@ -93,7 +93,7 @@ export function useAppActions({
   setAutoSelectEnabled,
   fetchInventory,
   isLinked,
-  logout,
+  markExpired,
   onManualStartWatching,
   setUpdateStatus,
   setFilter,
@@ -113,7 +113,7 @@ export function useAppActions({
     setAutoSelectEnabled,
     fetchInventory,
     isLinked,
-    logout,
+    markExpired,
     onManualStartWatching,
   });
 

--- a/src/renderer/shared/hooks/app/useAppModel.ts
+++ b/src/renderer/shared/hooks/app/useAppModel.ts
@@ -41,7 +41,7 @@ import type { FilterKey, View } from "@renderer/shared/types";
 import { isVerboseLoggingEnabled } from "@renderer/shared/utils/logger";
 
 export function useAppModel() {
-  const { auth, startLogin, logout } = useAuth();
+  const { auth, startLogin, logout, markExpired } = useAuth();
   const { theme, setTheme } = useTheme();
   const { accent, setAccent } = useAccent();
   const { fontPair, setFontPair } = useFontPair();
@@ -315,7 +315,7 @@ export function useAppModel() {
     setAutoSelectEnabled,
     fetchInventory,
     isLinked,
-    logout,
+    markExpired,
     onManualStartWatching: (channel) => {
       setManualWatchOverride({ at: Date.now(), game: channel.game });
     },

--- a/src/renderer/shared/hooks/app/useAuth.ts
+++ b/src/renderer/shared/hooks/app/useAuth.ts
@@ -21,6 +21,7 @@ type AuthHook = {
   auth: AuthState;
   startLogin: () => Promise<void>;
   logout: () => Promise<void>;
+  markExpired: () => Promise<void>;
 };
 
 export function useAuth(): AuthHook {
@@ -61,9 +62,20 @@ export function useAuth(): AuthHook {
     setAuth({ status: "idle" });
   };
 
+  const markExpired = async () => {
+    // Clear the dead token server-side, but keep the dashboard mounted by moving
+    // to a distinct "expired" state instead of "idle". Never stomps an in-flight
+    // re-login (pending) or an already-expired state.
+    await window.electronAPI.auth.logout();
+    setAuth((prev) =>
+      prev.status === "pending" || prev.status === "expired" ? prev : { status: "expired" },
+    );
+  };
+
   return {
     auth,
     startLogin,
     logout,
+    markExpired,
   };
 }

--- a/src/renderer/shared/hooks/app/useAuth.ts
+++ b/src/renderer/shared/hooks/app/useAuth.ts
@@ -64,9 +64,15 @@ export function useAuth(): AuthHook {
 
   const markExpired = async () => {
     // Clear the dead token server-side, but keep the dashboard mounted by moving
-    // to a distinct "expired" state instead of "idle". Never stomps an in-flight
-    // re-login (pending) or an already-expired state.
-    await window.electronAPI.auth.logout();
+    // to a distinct "expired" state instead of "idle". Best-effort cleanup: even
+    // if the backend logout rejects, still surface "expired" so the UI never gets
+    // stuck on this auto-triggered error path. Never stomps an in-flight re-login
+    // (pending) or an already-expired state.
+    try {
+      await window.electronAPI.auth.logout();
+    } catch {
+      // ignore — fall through to the state change below
+    }
     setAuth((prev) =>
       prev.status === "pending" || prev.status === "expired" ? prev : { status: "expired" },
     );

--- a/src/renderer/shared/hooks/watch/useWatchEngineSnapshot.ts
+++ b/src/renderer/shared/hooks/watch/useWatchEngineSnapshot.ts
@@ -81,6 +81,7 @@ export function useWatchEngineSnapshot({
         ? {
             recoveryCount: stallTracker.recoveryCount,
             sinceProgressMs: Math.max(0, now - stallTracker.lastProgressAt),
+            sinceProgressAt: stallTracker.lastProgressAt,
           }
         : null;
     const hasPredictiveProgress = Boolean(
@@ -119,6 +120,10 @@ export function useWatchEngineSnapshot({
               reason: suppressionReason,
               sinceAt: suppressionAt,
               holdRemainingMs: suppressionHoldRemainingMs,
+              holdUntil:
+                holdMs && typeof suppressionAt === "number" && Number.isFinite(suppressionAt)
+                  ? suppressionAt + holdMs
+                  : null,
             }
           : null,
       activeCooldowns,

--- a/src/renderer/shared/hooks/watch/useWatchEngineSnapshot.ts
+++ b/src/renderer/shared/hooks/watch/useWatchEngineSnapshot.ts
@@ -55,10 +55,6 @@ export function useWatchEngineSnapshot({
         : suppressionReason === "manual-stop"
           ? MANUAL_STOP_SUPPRESSION_HOLD_MS
           : 0;
-    const suppressionHoldRemainingMs =
-      holdMs && typeof suppressionAt === "number" && Number.isFinite(suppressionAt)
-        ? Math.max(0, suppressionAt + holdMs - now)
-        : 0;
     const activeCooldowns = Object.entries(stalledGameCooldownUntil)
       .map(([rawGame, until]) => ({ game: rawGame.trim(), until }))
       .filter(
@@ -80,7 +76,6 @@ export function useWatchEngineSnapshot({
       stallTracker && watching
         ? {
             recoveryCount: stallTracker.recoveryCount,
-            sinceProgressMs: Math.max(0, now - stallTracker.lastProgressAt),
             sinceProgressAt: stallTracker.lastProgressAt,
           }
         : null;
@@ -119,7 +114,6 @@ export function useWatchEngineSnapshot({
               game: suppressionGame,
               reason: suppressionReason,
               sinceAt: suppressionAt,
-              holdRemainingMs: suppressionHoldRemainingMs,
               holdUntil:
                 holdMs && typeof suppressionAt === "number" && Number.isFinite(suppressionAt)
                   ? suppressionAt + holdMs

--- a/src/renderer/shared/hooks/watch/useWatchingActions.ts
+++ b/src/renderer/shared/hooks/watch/useWatchingActions.ts
@@ -8,7 +8,7 @@ type Params = {
   setAutoSelectEnabled: (next: boolean) => void;
   fetchInventory: (opts?: { forceLoading?: boolean }) => Promise<void>;
   isLinked: boolean;
-  logout: () => Promise<void>;
+  markExpired: () => Promise<void>;
   onManualStartWatching?: (channel: ChannelEntry) => void;
 };
 
@@ -50,7 +50,7 @@ export function useWatchingActions({
   setAutoSelectEnabled,
   fetchInventory,
   isLinked,
-  logout,
+  markExpired,
   onManualStartWatching,
 }: Params) {
   const authErrorRef = useRef<AuthErrorTracker>({ count: 0, lastAt: 0 });
@@ -119,7 +119,7 @@ export function useWatchingActions({
           count: nextTracker.count,
         });
         if (fatalRevalidate || shouldLogout) {
-          void logout();
+          void markExpired();
           return;
         }
         logWarn("auth: transient error, keeping session", {
@@ -129,7 +129,7 @@ export function useWatchingActions({
         });
       })();
     },
-    [isLinked, stopWatching, logout],
+    [isLinked, stopWatching, markExpired],
   );
 
   const handleFetchInventory = useCallback(() => {

--- a/src/renderer/shared/i18n.tsx
+++ b/src/renderer/shared/i18n.tsx
@@ -84,6 +84,8 @@ const translations: Translations = {
     "session.loginBrowser": "Login with browser",
     "session.logout": "Logout",
     "session.login": "Login...",
+    "session.expired.title": "Session expired — engine paused.",
+    "session.expired.relogin": "Re-login",
 
     "nav.title": "Navigation",
 
@@ -1127,6 +1129,8 @@ const translations: Translations = {
     "session.loginBrowser": "Login mit Browser",
     "session.logout": "Logout",
     "session.login": "Login...",
+    "session.expired.title": "Sitzung abgelaufen — Engine pausiert.",
+    "session.expired.relogin": "Neu anmelden",
 
     "nav.title": "Navigation",
 

--- a/src/renderer/shared/i18n.tsx
+++ b/src/renderer/shared/i18n.tsx
@@ -310,6 +310,9 @@ const translations: Translations = {
     "control.watchEngineNext.idleNoChannels":
       "The engine will retarget to the next priority game after stall handling.",
     "control.watchEngineNext.idleReady": "Auto-select can pick one of the eligible live channels.",
+    "control.watchEngineNext.suppressedCountdown": "Resuming in {time} after the stall hold.",
+    "control.watchEngineNext.cooldownCountdown":
+      "Cooldown ends in {time}, then auto-select retries.",
     "control.watchEngineNext.idleNoWatchableDrops":
       "The engine waits for inventory/channel changes or moves to another target.",
     "control.watchEngineSuppression.manualStop": "manual stop",
@@ -1355,6 +1358,9 @@ const translations: Translations = {
       "Nach Stall-Handling retargetet die Engine auf das nächste Prioritäts-Game.",
     "control.watchEngineNext.idleReady":
       "Auto-Select kann einen der berechtigten Live-Streams starten.",
+    "control.watchEngineNext.suppressedCountdown": "Fährt in {time} fort, nach dem Stall-Hold.",
+    "control.watchEngineNext.cooldownCountdown":
+      "Cooldown endet in {time}, dann versucht Auto-Select erneut.",
     "control.watchEngineNext.idleNoWatchableDrops":
       "Die Engine wartet auf Inventory/Channel-Aenderungen oder wechselt auf ein anderes Ziel.",
     "control.watchEngineSuppression.manualStop": "manueller Stop",

--- a/src/renderer/shared/i18n.tsx
+++ b/src/renderer/shared/i18n.tsx
@@ -897,6 +897,7 @@ const translations: Translations = {
     "hero.title.claimNowReady": "Claim all available drops",
     "hero.button.claiming": "claiming…",
     "hero.claimFeedback.errorFallback": "Claim failed",
+    "hero.claim.retryIn": "retry in {time}",
 
     // queue.* — new namespace, QueuePanel
     "queue.header": "queue · next up",
@@ -1932,6 +1933,7 @@ const translations: Translations = {
     "hero.title.claimNowReady": "Alle verfügbaren Drops claimen",
     "hero.button.claiming": "claime…",
     "hero.claimFeedback.errorFallback": "Claim fehlgeschlagen",
+    "hero.claim.retryIn": "neuer Versuch in {time}",
 
     // queue.* — new namespace, QueuePanel
     "queue.header": "queue · als nächstes",

--- a/src/renderer/shared/types.ts
+++ b/src/renderer/shared/types.ts
@@ -2,6 +2,7 @@ export type AuthState =
   | { status: "idle" }
   | { status: "pending" }
   | { status: "ok" }
+  | { status: "expired" }
   | { status: "error"; message: string };
 
 export type ProfileState =

--- a/src/renderer/shared/types.ts
+++ b/src/renderer/shared/types.ts
@@ -224,4 +224,8 @@ export type ClaimStatus = {
   code?: string;
   title?: string;
   at: number;
+  /** Absolute ms; present on an error the engine scheduled a retry for (transient). */
+  nextRetryAt?: number;
+  /** Retry attempt count for the failing drop (1-based). */
+  attempts?: number;
 };


### PR DESCRIPTION
## Summary

Makes DropPilot's autopilot **explain itself** instead of speaking in machine. Three independent strands, all "pure function + thin component wrapper", **presentation-only** except the one intended auth change.

- **Live engine-status countdowns** — `useWatchEngineSnapshot` only read `now` once per memo, so hold/cooldown/no-progress timers were frozen. Now it exposes absolute deadlines (`holdUntil`, `sinceProgressAt`; cooldowns already had `until`) and `EngineStatusPanel` ticks them live via the existing `TimeText` leaf. New pure `narrateEngineCountdown` + tests.
- **Claim narration + retry visibility** — `HeroPanel` rendered the raw English `"Drop claim failed"` and ignored `claimStatus.code`. Now a new pure `narrateClaim` renders the localized `error.*` text and surfaces the retry backoff as a live "retry in 4m" — **transient = amber, terminal = red** — so an auto-retrying failure stops looking fatal. `ClaimStatus` carries `nextRetryAt`/`attempts`. New pure module + tests.
- **In-place session re-login** — a fatal auth error used to `stopWatching()` then silently `logout()`, dumping the user to a signed-out shell with no explanation. New `AuthState` `expired` variant + `markExpired()` keep the dashboard mounted and show a persistent, non-blocking `SessionExpiredBanner` with a **Re-login** button. The intentional Settings logout is untouched.

Spec: `docs/superpowers/specs/2026-06-13-engine-voice-design.md`
Plan: `docs/superpowers/plans/2026-06-13-engine-voice.md`

Out of scope (YAGNI): connection-health banner (separate Health Dashboard idea), per-row inventory retry, a "retry now" button, routing `expired` to the alert dispatcher.

## Test Plan

Automated (all green):
- [x] `npm run typecheck` (both tsconfigs)
- [x] `npm test` — 504 passing (new `claimNarration.test.ts`, `controlHelpers.test.ts`)
- [x] `npm run format:check`
- [x] `npm run build`

Manual (no render tests exist — `@testing-library/react` is not a dep):
- [x] Failing auto-claim shows amber "<reason> · retry in Nm"; a success shows green; a terminal failure shows red.
- [x] During a stall hold / cooldown, the collapsed "Next" line counts down live; expanded suppression/cooldown/no-progress rows tick.
- [x] On session expiry the dashboard stays mounted and the banner appears; **Re-login** returns to `ok` and the engine resumes; an intentional Settings logout still goes to the signed-out state (no banner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)