### PR TITLE
ci(release): trim dead macOS auto-update assets from releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -261,9 +261,13 @@ jobs:
           body_path: rn-work/release_body.md
           draft: ${{ steps.release_visibility.outputs.draft }}
           prerelease: ${{ steps.release_visibility.outputs.prerelease }}
+          # Keep the release lean. Windows installer + its updater feed
+          # (latest.yml) and blockmap for differential downloads — auto-update is
+          # Windows-only. Plus the macOS .dmg for manual install. Deliberately
+          # excludes the dead macOS auto-update artifacts (*-mac.zip,
+          # *.dmg.blockmap, latest-mac.yml) and electron-builder's builder-debug.yml.
           files: |
             artifacts/*.exe
-            artifacts/*.blockmap
+            artifacts/*.exe.blockmap
             artifacts/*.dmg
-            artifacts/*.zip
-            artifacts/*.yml
+            artifacts/latest.yml


### PR DESCRIPTION
## Was & warum

Der Upload-Glob im `release`-Job hat pauschal alles mit `*.blockmap`, `*.zip` und `*.yml` an jedes GitHub-Release gehängt. Dadurch landeten dort auch die **macOS-Auto-Update-Artefakte** (`*-mac.zip`, `*.dmg.blockmap`, `latest-mac.yml`) und electron-builders `builder-debug.yml`.

macOS-Auto-Update ist in DropPilot aber abgeschaltet (Auto-Update ist Windows-only, alle Pfade sind in `src/main` mit `process.platform === "win32"` gegated). Diese Dateien haben also keinen Zweck und blähten jedes Release um ~120 MB auf (allein die `*-mac.zip`).

## Änderung

Glob auf die vier relevanten Assets verengt:

| Datei | Zweck |
|---|---|
| `DropPilot-Setup-X.exe` | Windows-Installer |
| `DropPilot-Setup-X.exe.blockmap` | Delta-Download fürs Windows-Auto-Update |
| `latest.yml` | Update-Feed (Windows) |
| `DropPilot-X-arm64.dmg` | macOS, manuelle Installation |

Die Globs sind bewusst spezifisch: `*.exe.blockmap` greift nur den Windows-Blockmap (nicht die Mac-Blockmaps), und `latest.yml` ist ein exakter Name (matcht weder `latest-mac.yml` noch `builder-debug.yml`).

## Hinweise

- Greift erst beim nächsten getaggten Release. Bestehende Releases behalten ihre alten Assets.
- Der Zwischenschritt `Upload artifacts` (CI-Artefakte pro OS) bleibt absichtlich unverändert — er betrifft das Release nicht.

🤖 Generated with [Claude Code](https://claude.com/claude-code)