### PR TITLE
fix(release-notes): stop AI notes inventing audio/speech from figurative evidence

### DIFF
--- a/scripts/release-notes/lib/prompts.mjs
+++ b/scripts/release-notes/lib/prompts.mjs
@@ -9,6 +9,7 @@ export function buildGenerationPrompt(candidates) {
 Product facts you must respect:
 - DropPilot runs in the background; it has no in-app video playback.
 - Never imply that users watch streams inside the app.
+- DropPilot is silent: it has no audio, sound, speech, or voice output. Words like "voice", "narrate", or "announce" in the changes always describe on-screen text or status — never literal sound. Never write that users hear, listen to, or are read/spoken to.
 
 Below are the changes in this release that could be user-visible. Each line has an id.
 
@@ -20,6 +21,7 @@ Write 0 to 6 release-note bullets describing what users will notice. Rules:
 - If no change produces something a user would notice, return an empty "bullets" array. Zero bullets is a correct, common answer.
 - Each bullet must name the concrete feature, setting, panel, or behavior that changed. No generic quality claims (nothing like "improvements", "more stable", "better performance" without a concrete subject).
 - Plain language; describe outcomes, not implementation. Never mention file paths, commits, pull requests, refactoring, dependencies, CI, or version numbers.
+- Never claim a capability or output the cited changes do not literally state. In particular, do not turn a figurative word (e.g. "voice", "narrate") into a new sensory modality such as sound or speech; describe the literal on-screen result instead.
 
 Respond with ONLY this JSON shape (no markdown fences, no prose):
 {"bullets":[{"text":"...","evidence":["E1"]}]}`;
@@ -41,6 +43,7 @@ export function buildJudgePrompt(bullets, unitsById) {
   return `You review draft release-note bullets for DropPilot, a Twitch-Drops automation desktop app. For each bullet you get the changelog entries cited as its evidence. Judge strictly:
 
 - "supported": the bullet's claim follows from its cited entries alone. If the entries do not clearly state what the bullet claims, or you are unsure, answer false.
+- A bullet is NOT supported if it introduces a capability or sensory modality (audio, sound, speech, voice output, "hear", "spoken", "read aloud") that its cited entries do not literally name. Figurative words like "voice" or "narrate" in the evidence describe on-screen text and do NOT support audio or speech claims.
 - "concrete": the bullet names a specific feature, setting, panel, or behavior. Generic quality claims ("improvements", "more stable", "better performance", "enhanced stability") are not concrete.
 
 ${blocks}

--- a/scripts/release-notes/lib/prompts.test.mjs
+++ b/scripts/release-notes/lib/prompts.test.mjs
@@ -30,6 +30,14 @@ describe("buildGenerationPrompt", () => {
   it("demands pure JSON with the bullets/evidence shape", () => {
     expect(prompt).toContain('{"bullets":[{"text":"...","evidence":["E1"]}]}');
   });
+
+  it("forbids inventing audio/speech from figurative words like 'voice'/'narrate'", () => {
+    // Regression: the app is silent; "Engine Voice"/"narrate" must never become
+    // "hear audio updates"/"spoken alerts". Guardrail lives in product facts + rules.
+    expect(prompt).toContain("DropPilot is silent");
+    expect(prompt).toMatch(/never write that users hear/i);
+    expect(prompt).toMatch(/figurative word.*sensory modality|sensory modality.*figurative/i);
+  });
 });
 
 describe("buildJudgePrompt", () => {
@@ -64,6 +72,16 @@ describe("buildJudgePrompt", () => {
     const unitsById = new Map(CANDIDATES.map((u) => [u.id, u.text]));
     const prompt = buildJudgePrompt([{ text: "x", evidence: ["E1"] }], unitsById);
     expect(prompt).not.toMatch(/internal maintenance/i);
+  });
+
+  it("instructs the judge to reject invented audio/speech modalities", () => {
+    // Regression companion to the generation guardrail: even if a bullet slips
+    // through generation, the judge must drop "hear"/"spoken"/audio claims that
+    // figurative evidence ("voice"/"narrate") does not literally support.
+    const unitsById = new Map(CANDIDATES.map((u) => [u.id, u.text]));
+    const prompt = buildJudgePrompt([{ text: "x", evidence: ["E1"] }], unitsById);
+    expect(prompt).toMatch(/sensory modality/i);
+    expect(prompt).toMatch(/do NOT support audio or speech claims/i);
   });
 });
 


### PR DESCRIPTION
## Problem

Die generierten v3.4.1-Release-Notes behaupteten, die App rede jetzt:

> - **Hear real-time audio updates** about DropPilot's status … thanks to the new Engine Voice feature.
> - **Receive spoken alerts** when your session expires …

DropPilot ist lautlos — kein TTS, kein Audio, kein `speechSynthesis` im Repo. Beide Schutzschichten der Pipeline haben versagt:

1. **Generator** hat die Commit-Subjects `Engine Voice — narrate…`, `claim narration`, `countdown narration` **wörtlich** genommen und eine Audio-Modalität halluziniert. Die `Product facts` deckten nur Video ab, nichts zu Ton/Sprache.
2. **Judge** hat Bullet 2/3 als `supported:true` durchgewunken, weil „voice"/„narrate" wörtlich in der zitierten Evidence stehen — für einen lose lesenden Judge „stützt" das die Audio-Claims. Es gab keine Regel, dass eine neue Sinnesmodalität explizite Evidence braucht.

## Fix

Beide Prompts in `scripts/release-notes/lib/prompts.mjs` gehärtet:

- **Generator**: neuer Product-Fact („DropPilot is silent: no audio/sound/speech/voice output; ‚voice'/‚narrate' = On-Screen-Text") + Regel gegen das Erfinden einer Modalität aus figurativen Wörtern.
- **Judge**: ein Bullet ist *nicht* supported, wenn es eine Fähigkeit/Modalität (audio, sound, speech, „hear", „spoken") einführt, die die Evidence nicht wörtlich nennt.

Plus Regressionstests in `prompts.test.mjs`, die beide Guardrails pinnen.

## Verifikation

- `npx vitest run scripts/release-notes` → 74 passed
- `npm run format:check` → clean

Die *semantische* Wirkung (hält sich gpt-4o dran?) zeigt sich erst beim nächsten echten Release-Run — die Guardrails machen den Fehlklassifikator aber an beiden Stellen unwahrscheinlich. Im Anschluss kommt der Bump auf **v3.4.2** (v3.4.1 wurde wegen der fehlerhaften Notes gelöscht).

🤖 Generated with [Claude Code](https://claude.com/claude-code)