### PR TITLE
docs(readme): refresh content + presentation glow-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 <p>
 <a href="https://github.com/rxm96/droppilot/actions/workflows/build.yml"><img src="https://github.com/rxm96/droppilot/actions/workflows/build.yml/badge.svg" alt="Build" /></a>
 <a href="https://github.com/rxm96/droppilot/releases/latest"><img src="https://img.shields.io/github/v/release/rxm96/droppilot?sort=semver" alt="Latest release" /></a>
-<a href="https://github.com/rxm96/droppilot/releases"><img src="https://img.shields.io/github/downloads/rxm96/droppilot/total?color=brightgreen" alt="Total downloads" /></a>
 <img src="https://img.shields.io/badge/platforms-Windows%20%7C%20macOS-blue" alt="Platforms" />
 <a href="LICENSE"><img src="https://img.shields.io/github/license/rxm96/droppilot" alt="License: MIT" /></a>
 </p>

--- a/README.md
+++ b/README.md
@@ -1,12 +1,45 @@
-# DropPilot
+<div align="center">
 
-> **Download:** Grab the latest Windows installer from
-> [GitHub Releases](https://github.com/rxm96/droppilot/releases).
+<img src="icons/icon.png" width="120" alt="DropPilot" />
 
-DropPilot is a desktop app that automates Twitch Drops — quietly, in the
-background, while staying transparent about what it's doing. It tracks your drop
+<h1>DropPilot</h1>
+
+<p><strong>Automate Twitch Drops — quietly in the background, transparent about what it's doing.</strong></p>
+
+<p>
+<a href="https://github.com/rxm96/droppilot/actions/workflows/build.yml"><img src="https://github.com/rxm96/droppilot/actions/workflows/build.yml/badge.svg" alt="Build" /></a>
+<a href="https://github.com/rxm96/droppilot/releases/latest"><img src="https://img.shields.io/github/v/release/rxm96/droppilot?sort=semver" alt="Latest release" /></a>
+<a href="https://github.com/rxm96/droppilot/releases"><img src="https://img.shields.io/github/downloads/rxm96/droppilot/total?color=brightgreen" alt="Total downloads" /></a>
+<img src="https://img.shields.io/badge/platforms-Windows%20%7C%20macOS-blue" alt="Platforms" />
+<a href="LICENSE"><img src="https://img.shields.io/github/license/rxm96/droppilot" alt="License: MIT" /></a>
+</p>
+
+<p><a href="https://github.com/rxm96/droppilot/releases/latest"><strong>⬇&nbsp; Download the latest Windows installer</strong></a></p>
+
+</div>
+
+---
+
+DropPilot is a desktop app that automates Twitch Drops. It tracks your drop
 inventory, picks and watches an eligible stream, switches when that stream goes
-down, and (optionally) claims drops for you.
+down, and (optionally) claims drops for you — all in the background, while
+staying transparent about what it's doing.
+
+[![Overview](docs/screenshots/overview.png)](docs/screenshots/overview.png)
+
+## Contents
+
+- [Features](#features)
+- [Screenshots](#screenshots)
+- [Quick start](#quick-start)
+- [How it works](#how-it-works)
+- [Releases & updates](#releases--updates)
+- [Configuration & data](#configuration--data)
+- [Debug tools](#debug-tools)
+- [Troubleshooting](#troubleshooting)
+- [Tech stack](#tech-stack)
+- [Acknowledgements](#acknowledgements)
+- [License](#license)
 
 ## Features
 
@@ -18,24 +51,25 @@ down, and (optionally) claims drops for you.
 - **Auto-claim** (optional) — claims completed drops and keeps an activity audit.
 - **Warmup mode** (optional) — briefly watches a stream to discover drops when no
   priority game is currently active.
-- **Alerts** — new drops, auto-claim, drop ending soon, watch errors.
+- **Engine transparency** — a live engine-status rail (Standby → Scanning →
+  Watching → Recovering → Hold), a claim-retry countdown, and a session-expired
+  banner with one-click re-login instead of a silent logout.
+- **Alerts** — desktop notifications for new drops, auto-claim, auto-switch,
+  "drop ending soon," and watch errors.
+- **Discord / webhook notifications** — push those same alerts to a Discord
+  webhook (or any compatible endpoint), independent of desktop notifications.
+  HTTPS-only with an SSRF guard, plus a one-click test send.
 - **Browser-based login** — no credentials are stored by the app.
 - **Demo mode** — explore the full UI without a live Twitch account.
 - **Debug tools** — live logs, a state snapshot, and perf/CPU sampling (off by default).
 
 ## Screenshots
 
-> Dark theme with demo data.
+> Dark theme with demo data. (Overview is shown above.)
 
-| Overview | Stats |
-| --- | --- |
-| [![Overview](docs/screenshots/overview.png)](docs/screenshots/overview.png) | [![Stats](docs/screenshots/stats.png)](docs/screenshots/stats.png) |
-| **Inventory** | **Control** |
-| [![Inventory](docs/screenshots/inventory.png)](docs/screenshots/inventory.png) | [![Control](docs/screenshots/control.png)](docs/screenshots/control.png) |
-
-## Tech stack
-
-Electron 40 · React 19 · Vite 7 · TypeScript · Tailwind CSS v4 · Vitest
+| Stats | Inventory | Control |
+| --- | --- | --- |
+| [![Stats](docs/screenshots/stats.png)](docs/screenshots/stats.png) | [![Inventory](docs/screenshots/inventory.png)](docs/screenshots/inventory.png) | [![Control](docs/screenshots/control.png)](docs/screenshots/control.png) |
 
 ## Quick start
 
@@ -78,10 +112,11 @@ in [`docs/watch-flow.puml`](docs/watch-flow.puml).
 
 ## Releases & updates
 
-Releases are published to GitHub Releases (Windows `.exe` + macOS artifacts) and
+Releases are published to GitHub Releases (Windows `.exe` + a macOS `.dmg`) and
 built by CI when a `v*` tag is pushed. The app auto-updates on Windows and offers
 two channels — **stable** and **preview** — selectable in Settings → Updates, which
-also shows the in-app release history. See `CONTRIBUTING.md` for how to cut a release.
+also shows the in-app release history. See [`CONTRIBUTING.md`](CONTRIBUTING.md) for
+how to cut a release.
 
 ## Configuration & data
 
@@ -100,6 +135,10 @@ CPU snapshots appear in the Debug snapshot.
 - **App feels slow** → disable the Debug tab and restart.
 - **Need verbose logs** → enable Debug tools in Settings.
 
+## Tech stack
+
+Electron 42 · React 19 · Vite 7 · TypeScript · Tailwind CSS v4 · Vitest
+
 ## Acknowledgements
 
 DropPilot's drop-mining approach is heavily informed by
@@ -114,5 +153,4 @@ reproduced in [`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md).
 
 ## License
 
-MIT
-
+MIT — see [`LICENSE`](LICENSE).

--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ staying transparent about what it's doing.
 - **Auto-claim** (optional) — claims completed drops and keeps an activity audit.
 - **Warmup mode** (optional) — briefly watches a stream to discover drops when no
   priority game is currently active.
-- **Engine transparency** — a live engine-status rail (Standby → Scanning →
-  Watching → Recovering → Hold), a claim-retry countdown, and a session-expired
-  banner with one-click re-login instead of a silent logout.
+- **Stays transparent** — a live status readout (scanning, watching,
+  recovering…), claim-retry countdowns, and a one-click prompt to sign back in
+  when your Twitch session expires.
 - **Alerts** — desktop notifications for new drops, auto-claim, auto-switch,
   "drop ending soon," and watch errors.
 - **Discord / webhook notifications** — push those same alerts to a Discord

--- a/README.md
+++ b/README.md
@@ -42,25 +42,29 @@ staying transparent about what it's doing.
 
 ## Features
 
-- **Live inventory** — drop progress, claim status, and per-drop ETA in real time.
-- **Target + priority** — build a priority list of games; the app focuses on the
-  most important actionable game and rotates through the list.
-- **Auto-watch** — auto-selects a stream, auto-switches when the current one
-  disappears, and recovers from stalls (no watch-time progress) on its own.
-- **Auto-claim** (optional) — claims completed drops and keeps an activity audit.
-- **Warmup mode** (optional) — briefly watches a stream to discover drops when no
-  priority game is currently active.
+- **Live inventory** — every drop's progress, claim status, and time remaining,
+  all in real time.
+- **Priority list** — rank the games you care about; DropPilot works down the
+  list, focusing on the highest one it can actually make progress on right now.
+- **Hands-off watching** — it picks an eligible stream, switches automatically
+  when one goes offline, and recovers on its own when progress stalls — no
+  babysitting.
+- **Auto-claim** (optional) — claims finished drops for you and keeps a record
+  of everything it's done.
 - **Stays transparent** — a live status readout (scanning, watching,
   recovering…), claim-retry countdowns, and a one-click prompt to sign back in
   when your Twitch session expires.
-- **Alerts** — desktop notifications for new drops, auto-claim, auto-switch,
-  "drop ending soon," and watch errors.
-- **Discord / webhook notifications** — push those same alerts to a Discord
-  webhook (or any compatible endpoint), independent of desktop notifications.
-  HTTPS-only with an SSRF guard, plus a one-click test send.
-- **Browser-based login** — no credentials are stored by the app.
-- **Demo mode** — explore the full UI without a live Twitch account.
-- **Debug tools** — live logs, a state snapshot, and perf/CPU sampling (off by default).
+- **Alerts** — desktop notifications for new drops, auto-claims, stream
+  switches, drops about to end, and watch errors.
+- **Discord / webhook notifications** — get those same alerts in Discord (or any
+  compatible webhook), separate from desktop notifications, with a one-click
+  test send.
+- **Browser-based login** — sign in through Twitch's own page; DropPilot never
+  stores your credentials.
+- **Demo mode** — explore the whole interface with sample data, no Twitch
+  account needed.
+- **Debug tools** (off by default) — live logs, a state snapshot, and
+  performance/CPU sampling for when you need to dig in.
 
 ## Screenshots
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 <div align="center">
 
-<img src="icons/icon.png" width="120" alt="DropPilot" />
-
-<h1>DropPilot</h1>
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/brand/banner-dark.svg" />
+  <img src="docs/brand/banner-light.svg" width="360" alt="DropPilot" />
+</picture>
 
 <p><strong>Automate Twitch Drops — quietly in the background, transparent about what it's doing.</strong></p>
 
@@ -13,7 +14,9 @@
 <a href="LICENSE"><img src="https://img.shields.io/github/license/rxm96/droppilot" alt="License: MIT" /></a>
 </p>
 
-<p><a href="https://github.com/rxm96/droppilot/releases/latest"><strong>⬇&nbsp; Download the latest Windows installer</strong></a></p>
+<p>
+<a href="https://github.com/rxm96/droppilot/releases/latest"><img src="https://img.shields.io/badge/%E2%AC%87%20Download%20for%20Windows-7c5fe6?style=for-the-badge&logo=windows&logoColor=white" alt="Download for Windows" /></a>
+</p>
 
 </div>
 
@@ -42,29 +45,29 @@ staying transparent about what it's doing.
 
 ## Features
 
-- **Live inventory** — every drop's progress, claim status, and time remaining,
-  all in real time.
-- **Priority list** — rank the games you care about; DropPilot works down the
-  list, focusing on the highest one it can actually make progress on right now.
-- **Hands-off watching** — it picks an eligible stream, switches automatically
-  when one goes offline, and recovers on its own when progress stalls — no
-  babysitting.
-- **Auto-claim** (optional) — claims finished drops for you and keeps a record
-  of everything it's done.
-- **Stays transparent** — a live status readout (scanning, watching,
-  recovering…), claim-retry countdowns, and a one-click prompt to sign back in
-  when your Twitch session expires.
-- **Alerts** — desktop notifications for new drops, auto-claims, stream
-  switches, drops about to end, and watch errors.
-- **Discord / webhook notifications** — get those same alerts in Discord (or any
-  compatible webhook), separate from desktop notifications, with a one-click
-  test send.
-- **Browser-based login** — sign in through Twitch's own page; DropPilot never
-  stores your credentials.
-- **Demo mode** — explore the whole interface with sample data, no Twitch
-  account needed.
-- **Debug tools** (off by default) — live logs, a state snapshot, and
-  performance/CPU sampling for when you need to dig in.
+<table>
+<tr>
+<td width="50%"><img src="docs/brand/feat-inventory.svg" width="20" /> <strong>Live inventory</strong><br />Every drop's progress, claim status and time left, in real time.</td>
+<td width="50%"><img src="docs/brand/feat-priority.svg" width="20" /> <strong>Priority list</strong><br />Rank your games; DropPilot works the highest one it can progress right now.</td>
+</tr>
+<tr>
+<td><img src="docs/brand/feat-watching.svg" width="20" /> <strong>Hands-off watching</strong><br />Picks an eligible stream, switches when one goes offline, and recovers when progress stalls.</td>
+<td><img src="docs/brand/feat-autoclaim.svg" width="20" /> <strong>Auto-claim</strong><br />Optionally claims finished drops for you and keeps a record of everything it's done.</td>
+</tr>
+<tr>
+<td><img src="docs/brand/feat-alerts.svg" width="20" /> <strong>Desktop alerts</strong><br />New drops, auto-claims, stream switches, drops about to end, and watch errors.</td>
+<td><img src="docs/brand/feat-discord.svg" width="20" /> <strong>Discord / webhook</strong><br />The same alerts in Discord (or any compatible webhook), with a one-click test send.</td>
+</tr>
+<tr>
+<td><img src="docs/brand/feat-login.svg" width="20" /> <strong>Browser-based login</strong><br />Sign in through Twitch's own page; DropPilot never stores your credentials.</td>
+<td><img src="docs/brand/feat-demo.svg" width="20" /> <strong>Demo mode</strong><br />Explore the whole interface with sample data — no Twitch account needed.</td>
+</tr>
+</table>
+
+DropPilot also stays out of your way while it works: a live status readout
+(scanning, watching, recovering…), claim-retry countdowns, and a one-click prompt
+to sign back in when your Twitch session expires. A **Debug** tab (off by
+default) adds live logs and a state snapshot for when you need to dig in.
 
 ## Screenshots
 

--- a/docs/brand/banner-dark.svg
+++ b/docs/brand/banner-dark.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 140" width="320" height="140" role="img" aria-label="DropPilot">
+  <g transform="translate(126.4,14) scale(2.8)">
+    <path d="M12 2C12 2 5 9 5 14a7 7 0 1 0 14 0C19 9 12 2 12 2Z" fill="#a78bfa" />
+    <path d="M12 9L15.5 18.5L12 16L8.5 18.5Z" fill="#ffffff" />
+  </g>
+  <text x="160" y="120" text-anchor="middle" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif" font-size="40" font-weight="700" letter-spacing="-1">
+    <tspan fill="#e6edf3">Drop</tspan><tspan fill="#a78bfa">Pilot</tspan>
+  </text>
+</svg>

--- a/docs/brand/banner-light.svg
+++ b/docs/brand/banner-light.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 140" width="320" height="140" role="img" aria-label="DropPilot">
+  <g transform="translate(126.4,14) scale(2.8)">
+    <path d="M12 2C12 2 5 9 5 14a7 7 0 1 0 14 0C19 9 12 2 12 2Z" fill="#7c5fe6" />
+    <path d="M12 9L15.5 18.5L12 16L8.5 18.5Z" fill="#ffffff" />
+  </g>
+  <text x="160" y="120" text-anchor="middle" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif" font-size="40" font-weight="700" letter-spacing="-1">
+    <tspan fill="#1a1c1f">Drop</tspan><tspan fill="#7c5fe6">Pilot</tspan>
+  </text>
+</svg>

--- a/docs/brand/feat-alerts.svg
+++ b/docs/brand/feat-alerts.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#a78bfa" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" role="img" aria-label="Desktop alerts">
+  <path d="M10 5a2 2 0 0 1 4 0 7 7 0 0 1 4 6v3a4 4 0 0 0 2 3H4a4 4 0 0 0 2-3v-3a7 7 0 0 1 4-6" />
+  <path d="M9 17v1a3 3 0 0 0 6 0v-1" />
+</svg>

--- a/docs/brand/feat-autoclaim.svg
+++ b/docs/brand/feat-autoclaim.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#a78bfa" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" role="img" aria-label="Auto-claim">
+  <circle cx="12" cy="12" r="9" />
+  <path d="M8.5 12.5l2.5 2.5 4.5-5" />
+</svg>

--- a/docs/brand/feat-demo.svg
+++ b/docs/brand/feat-demo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#a78bfa" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" role="img" aria-label="Demo mode">
+  <path d="M8.5 3h7" />
+  <path d="M9 3v6l-4.5 8a1.8 1.8 0 0 0 1.6 2.7h11.8a1.8 1.8 0 0 0 1.6-2.7l-4.5-8v-6" />
+  <path d="M6.5 15h11" />
+</svg>

--- a/docs/brand/feat-discord.svg
+++ b/docs/brand/feat-discord.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#a78bfa" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" role="img" aria-label="Discord / webhook">
+  <circle cx="9" cy="12" r="1" fill="#a78bfa" stroke="none" />
+  <circle cx="15" cy="12" r="1" fill="#a78bfa" stroke="none" />
+  <path d="M7.5 7.5c3.5-1 5.5-1 9 0" />
+  <path d="M7 16.5c3.5 1 6.5 1 10 0" />
+  <path d="M15.5 17c0 1 1.5 3 2 3 1.5 0 2.8-1.7 3.5-3 .7-1.7 .5-5.8-1.5-11.5-1.5-1-3-1.3-4.5-1.5l-1 2.5" />
+  <path d="M8.5 17c0 1-1.4 3-1.8 3-1.4 0-2.7-1.7-3.3-3-.6-1.7-.5-5.8 1.4-11.5 1.4-1 2.8-1.3 4.2-1.5l1 2.5" />
+</svg>

--- a/docs/brand/feat-inventory.svg
+++ b/docs/brand/feat-inventory.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#a78bfa" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" role="img" aria-label="Live inventory">
+  <path d="M4 6h11" />
+  <path d="M4 12h11" />
+  <path d="M4 18h7" />
+  <path d="M15 17l2 2 4-4" />
+</svg>

--- a/docs/brand/feat-login.svg
+++ b/docs/brand/feat-login.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#a78bfa" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" role="img" aria-label="Browser-based login">
+  <rect x="3" y="5" width="18" height="14" rx="2" />
+  <path d="M3 9h18" />
+</svg>

--- a/docs/brand/feat-priority.svg
+++ b/docs/brand/feat-priority.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#a78bfa" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" role="img" aria-label="Priority list">
+  <path d="M5 7l3-3 3 3" />
+  <path d="M8 4v16" />
+  <path d="M19 17l-3 3-3-3" />
+  <path d="M16 20V4" />
+</svg>

--- a/docs/brand/feat-watching.svg
+++ b/docs/brand/feat-watching.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#a78bfa" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" role="img" aria-label="Hands-off watching">
+  <path d="M7 5v14l11-7z" />
+</svg>

--- a/docs/superpowers/plans/2026-06-15-readme-overhaul-brand-assets.md
+++ b/docs/superpowers/plans/2026-06-15-readme-overhaul-brand-assets.md
@@ -1,0 +1,441 @@
+# README overhaul + brand assets Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a resolution-independent SVG logo (droplet + heading) and a fresher, cooler README with a full hero, download CTA, and an icon-backed feature grid.
+
+**Architecture:** Pure docs + brand-assets change. All visual richness lives in committed SVG files (one banner per theme, eight feature icons, one mark) because GitHub strips inline CSS/`style`/`class` from markdown. The README references them via `<picture>`, `<img>`, shields badges, and a markdown/HTML table. No application source code changes.
+
+**Tech Stack:** Hand-authored SVG, GitHub-flavoured Markdown with the safe HTML subset (`<div align>`, `<picture>`, `<table>`, `<img>`), shields.io.
+
+---
+
+## Why no unit tests here
+
+The project's testing convention (`CLAUDE.md`) covers pure functions only — there is nothing executable in this change. `format:check` globs only `src/**/*.{ts,tsx,css}` and `scripts/release-notes/**/*.mjs`, so it does **not** touch `README.md`, `docs/**`, or `icons/**` — no Prettier gate applies to these files. Verification per task is therefore: (a) the SVG/HTML is well-formed XML, and (b) it renders as intended. Well-formedness check (Windows PowerShell, zero deps):
+
+```powershell
+[xml](Get-Content -Raw <path>); 'OK'
+```
+
+It prints `OK` on success and throws on malformed markup.
+
+## File structure
+
+Create:
+
+- `icons/logo.svg` — the mark only (droplet + white arrow). Single source of truth for future app-icon/tray raster.
+- `docs/brand/banner-dark.svg`, `docs/brand/banner-light.svg` — hero lockup (mark above wordmark), one per theme.
+- `docs/brand/feat-inventory.svg`, `feat-priority.svg`, `feat-watching.svg`, `feat-autoclaim.svg`, `feat-alerts.svg`, `feat-discord.svg`, `feat-login.svg`, `feat-demo.svg` — eight monoline feature icons.
+
+Modify:
+
+- `README.md` — new hero, download CTA, feature table, light copy pass.
+
+Leave untouched: `icons/icon.png` and `icons/tray/` (app-icon/tray regeneration is a later, separate step).
+
+---
+
+### Task 1: The mark — `icons/logo.svg`
+
+**Files:**
+- Create: `icons/logo.svg`
+
+- [ ] **Step 1: Create the file**
+
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="256" height="256" role="img" aria-label="DropPilot">
+  <path d="M12 2C12 2 5 9 5 14a7 7 0 1 0 14 0C19 9 12 2 12 2Z" fill="#a78bfa" />
+  <path d="M12 9L15.5 18.5L12 16L8.5 18.5Z" fill="#ffffff" />
+</svg>
+```
+
+- [ ] **Step 2: Verify it is well-formed**
+
+Run: `[xml](Get-Content -Raw icons/logo.svg); 'OK'`
+Expected: prints `OK`, no exception.
+
+- [ ] **Step 3: Eyeball it**
+
+Open `icons/logo.svg` in a browser (or VS Code SVG preview). Expected: a violet teardrop with a crisp white upward navigation arrow centered in the bulb. No clipping, no stray fills.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add icons/logo.svg
+git commit -m "feat(brand): add vector logo mark (icons/logo.svg)"
+```
+
+---
+
+### Task 2: Hero banners — `docs/brand/banner-{dark,light}.svg`
+
+**Files:**
+- Create: `docs/brand/banner-dark.svg`
+- Create: `docs/brand/banner-light.svg`
+
+- [ ] **Step 1: Create `docs/brand/banner-dark.svg`**
+
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 140" width="320" height="140" role="img" aria-label="DropPilot">
+  <g transform="translate(126.4,14) scale(2.8)">
+    <path d="M12 2C12 2 5 9 5 14a7 7 0 1 0 14 0C19 9 12 2 12 2Z" fill="#a78bfa" />
+    <path d="M12 9L15.5 18.5L12 16L8.5 18.5Z" fill="#ffffff" />
+  </g>
+  <text x="160" y="120" text-anchor="middle" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif" font-size="40" font-weight="700" letter-spacing="-1">
+    <tspan fill="#e6edf3">Drop</tspan><tspan fill="#a78bfa">Pilot</tspan>
+  </text>
+</svg>
+```
+
+- [ ] **Step 2: Create `docs/brand/banner-light.svg`** (same geometry, light-theme colors)
+
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 140" width="320" height="140" role="img" aria-label="DropPilot">
+  <g transform="translate(126.4,14) scale(2.8)">
+    <path d="M12 2C12 2 5 9 5 14a7 7 0 1 0 14 0C19 9 12 2 12 2Z" fill="#7c5fe6" />
+    <path d="M12 9L15.5 18.5L12 16L8.5 18.5Z" fill="#ffffff" />
+  </g>
+  <text x="160" y="120" text-anchor="middle" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif" font-size="40" font-weight="700" letter-spacing="-1">
+    <tspan fill="#1a1c1f">Drop</tspan><tspan fill="#7c5fe6">Pilot</tspan>
+  </text>
+</svg>
+```
+
+- [ ] **Step 3: Verify both are well-formed**
+
+Run:
+```powershell
+[xml](Get-Content -Raw docs/brand/banner-dark.svg); [xml](Get-Content -Raw docs/brand/banner-light.svg); 'OK'
+```
+Expected: prints `OK`.
+
+- [ ] **Step 4: Eyeball both**
+
+Open each in a browser. Expected: mark centered on top, "Drop" + "Pilot" wordmark centered beneath (Pilot in violet), wordmark not clipped by the 320-wide viewBox. The light banner should be legible on a white page, the dark on a near-black page.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/brand/banner-dark.svg docs/brand/banner-light.svg
+git commit -m "feat(brand): add dark/light README hero banners"
+```
+
+---
+
+### Task 3: Feature icons — `docs/brand/feat-*.svg`
+
+All eight share root attributes `fill="none" stroke="#a78bfa" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"` so a single mid-tone violet line reads on both GitHub themes. Discord eye-dots override with a solid fill.
+
+**Files:**
+- Create: `docs/brand/feat-inventory.svg`, `feat-priority.svg`, `feat-watching.svg`, `feat-autoclaim.svg`, `feat-alerts.svg`, `feat-discord.svg`, `feat-login.svg`, `feat-demo.svg`
+
+- [ ] **Step 1: `feat-inventory.svg`**
+
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#a78bfa" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" role="img" aria-label="Live inventory">
+  <path d="M4 6h11" />
+  <path d="M4 12h11" />
+  <path d="M4 18h7" />
+  <path d="M15 17l2 2 4-4" />
+</svg>
+```
+
+- [ ] **Step 2: `feat-priority.svg`**
+
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#a78bfa" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" role="img" aria-label="Priority list">
+  <path d="M5 7l3-3 3 3" />
+  <path d="M8 4v16" />
+  <path d="M19 17l-3 3-3-3" />
+  <path d="M16 20V4" />
+</svg>
+```
+
+- [ ] **Step 3: `feat-watching.svg`**
+
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#a78bfa" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" role="img" aria-label="Hands-off watching">
+  <path d="M7 5v14l11-7z" />
+</svg>
+```
+
+- [ ] **Step 4: `feat-autoclaim.svg`**
+
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#a78bfa" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" role="img" aria-label="Auto-claim">
+  <circle cx="12" cy="12" r="9" />
+  <path d="M8.5 12.5l2.5 2.5 4.5-5" />
+</svg>
+```
+
+- [ ] **Step 5: `feat-alerts.svg`**
+
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#a78bfa" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" role="img" aria-label="Desktop alerts">
+  <path d="M10 5a2 2 0 0 1 4 0 7 7 0 0 1 4 6v3a4 4 0 0 0 2 3H4a4 4 0 0 0 2-3v-3a7 7 0 0 1 4-6" />
+  <path d="M9 17v1a3 3 0 0 0 6 0v-1" />
+</svg>
+```
+
+- [ ] **Step 6: `feat-discord.svg`** (eye-dots get a solid violet fill)
+
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#a78bfa" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" role="img" aria-label="Discord / webhook">
+  <circle cx="9" cy="12" r="1" fill="#a78bfa" stroke="none" />
+  <circle cx="15" cy="12" r="1" fill="#a78bfa" stroke="none" />
+  <path d="M7.5 7.5c3.5-1 5.5-1 9 0" />
+  <path d="M7 16.5c3.5 1 6.5 1 10 0" />
+  <path d="M15.5 17c0 1 1.5 3 2 3 1.5 0 2.8-1.7 3.5-3 .7-1.7 .5-5.8-1.5-11.5-1.5-1-3-1.3-4.5-1.5l-1 2.5" />
+  <path d="M8.5 17c0 1-1.4 3-1.8 3-1.4 0-2.7-1.7-3.3-3-.6-1.7-.5-5.8 1.4-11.5 1.4-1 2.8-1.3 4.2-1.5l1 2.5" />
+</svg>
+```
+
+- [ ] **Step 7: `feat-login.svg`**
+
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#a78bfa" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" role="img" aria-label="Browser-based login">
+  <rect x="3" y="5" width="18" height="14" rx="2" />
+  <path d="M3 9h18" />
+</svg>
+```
+
+- [ ] **Step 8: `feat-demo.svg`**
+
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#a78bfa" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" role="img" aria-label="Demo mode">
+  <path d="M8.5 3h7" />
+  <path d="M9 3v6l-4.5 8a1.8 1.8 0 0 0 1.6 2.7h11.8a1.8 1.8 0 0 0 1.6-2.7l-4.5-8v-6" />
+  <path d="M6.5 15h11" />
+</svg>
+```
+
+- [ ] **Step 9: Verify all eight are well-formed**
+
+Run:
+```powershell
+Get-ChildItem docs/brand/feat-*.svg | ForEach-Object { [xml](Get-Content -Raw $_.FullName) | Out-Null; "$($_.Name) OK" }
+```
+Expected: one `<name> OK` line per file, no exception.
+
+- [ ] **Step 10: Eyeball the set**
+
+Open the eight files (or drag the `docs/brand` folder into a browser). Expected: each is a recognizable violet line icon at 24px — list+check, two sort arrows, play triangle, circled check, bell, Discord mark with two solid eyes, browser window, flask. Each must still read at 20px (the README render size).
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add docs/brand/feat-inventory.svg docs/brand/feat-priority.svg docs/brand/feat-watching.svg docs/brand/feat-autoclaim.svg docs/brand/feat-alerts.svg docs/brand/feat-discord.svg docs/brand/feat-login.svg docs/brand/feat-demo.svg
+git commit -m "feat(brand): add eight monoline feature icons"
+```
+
+---
+
+### Task 4: README — hero, download CTA, feature grid, copy pass
+
+**Files:**
+- Modify: `README.md` (replace the whole file with the content below)
+
+- [ ] **Step 1: Replace `README.md` with this exact content**
+
+````markdown
+<div align="center">
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/brand/banner-dark.svg" />
+  <img src="docs/brand/banner-light.svg" width="360" alt="DropPilot" />
+</picture>
+
+<p><strong>Automate Twitch Drops — quietly in the background, transparent about what it's doing.</strong></p>
+
+<p>
+<a href="https://github.com/rxm96/droppilot/actions/workflows/build.yml"><img src="https://github.com/rxm96/droppilot/actions/workflows/build.yml/badge.svg" alt="Build" /></a>
+<a href="https://github.com/rxm96/droppilot/releases/latest"><img src="https://img.shields.io/github/v/release/rxm96/droppilot?sort=semver" alt="Latest release" /></a>
+<img src="https://img.shields.io/badge/platforms-Windows%20%7C%20macOS-blue" alt="Platforms" />
+<a href="LICENSE"><img src="https://img.shields.io/github/license/rxm96/droppilot" alt="License: MIT" /></a>
+</p>
+
+<p>
+<a href="https://github.com/rxm96/droppilot/releases/latest"><img src="https://img.shields.io/badge/%E2%AC%87%20Download%20for%20Windows-7c5fe6?style=for-the-badge&logo=windows&logoColor=white" alt="Download for Windows" /></a>
+</p>
+
+</div>
+
+---
+
+DropPilot is a desktop app that automates Twitch Drops. It tracks your drop
+inventory, picks and watches an eligible stream, switches when that stream goes
+down, and (optionally) claims drops for you — all in the background, while
+staying transparent about what it's doing.
+
+[![Overview](docs/screenshots/overview.png)](docs/screenshots/overview.png)
+
+## Contents
+
+- [Features](#features)
+- [Screenshots](#screenshots)
+- [Quick start](#quick-start)
+- [How it works](#how-it-works)
+- [Releases & updates](#releases--updates)
+- [Configuration & data](#configuration--data)
+- [Debug tools](#debug-tools)
+- [Troubleshooting](#troubleshooting)
+- [Tech stack](#tech-stack)
+- [Acknowledgements](#acknowledgements)
+- [License](#license)
+
+## Features
+
+<table>
+<tr>
+<td width="50%"><img src="docs/brand/feat-inventory.svg" width="20" /> <strong>Live inventory</strong><br />Every drop's progress, claim status and time left, in real time.</td>
+<td width="50%"><img src="docs/brand/feat-priority.svg" width="20" /> <strong>Priority list</strong><br />Rank your games; DropPilot works the highest one it can progress right now.</td>
+</tr>
+<tr>
+<td><img src="docs/brand/feat-watching.svg" width="20" /> <strong>Hands-off watching</strong><br />Picks an eligible stream, switches when one goes offline, and recovers when progress stalls.</td>
+<td><img src="docs/brand/feat-autoclaim.svg" width="20" /> <strong>Auto-claim</strong><br />Optionally claims finished drops for you and keeps a record of everything it's done.</td>
+</tr>
+<tr>
+<td><img src="docs/brand/feat-alerts.svg" width="20" /> <strong>Desktop alerts</strong><br />New drops, auto-claims, stream switches, drops about to end, and watch errors.</td>
+<td><img src="docs/brand/feat-discord.svg" width="20" /> <strong>Discord / webhook</strong><br />The same alerts in Discord (or any compatible webhook), with a one-click test send.</td>
+</tr>
+<tr>
+<td><img src="docs/brand/feat-login.svg" width="20" /> <strong>Browser-based login</strong><br />Sign in through Twitch's own page; DropPilot never stores your credentials.</td>
+<td><img src="docs/brand/feat-demo.svg" width="20" /> <strong>Demo mode</strong><br />Explore the whole interface with sample data — no Twitch account needed.</td>
+</tr>
+</table>
+
+DropPilot also stays out of your way while it works: a live status readout
+(scanning, watching, recovering…), claim-retry countdowns, and a one-click prompt
+to sign back in when your Twitch session expires. A **Debug** tab (off by
+default) adds live logs and a state snapshot for when you need to dig in.
+
+## Screenshots
+
+> Dark theme with demo data. (Overview is shown above.)
+
+| Stats | Inventory | Control |
+| --- | --- | --- |
+| [![Stats](docs/screenshots/stats.png)](docs/screenshots/stats.png) | [![Inventory](docs/screenshots/inventory.png)](docs/screenshots/inventory.png) | [![Control](docs/screenshots/control.png)](docs/screenshots/control.png) |
+
+## Quick start
+
+```bash
+npm install
+npm run dev      # launches the app (Vite + Electron, hot reload)
+```
+
+The most common scripts:
+
+| Script | Purpose |
+| --- | --- |
+| `npm run dev` | Run the app in development (hot reload) |
+| `npm run build` | Build the renderer (`dist/`) + main & preload (`dist-electron/`) |
+| `npm test` | Run the test suite (Vitest); `npm run test:watch` to watch |
+| `npm run lint` | ESLint |
+| `npm run format` | Prettier (`format:check` to verify) |
+
+For local-dev details, testing conventions, commit style, and the release process,
+see [`CONTRIBUTING.md`](CONTRIBUTING.md).
+
+## How it works
+
+DropPilot is a standard three-layer Electron app:
+
+- **`src/main`** — Electron main process: app lifecycle, the IPC handlers, JSON
+  persistence in the user-data directory, and the entire Twitch integration
+  (`src/main/twitch`: GQL client, high-level service, live PubSub events, channel
+  tracking, watch-minute pings). **All network calls happen here**, never in the
+  renderer.
+- **`src/preload`** — the context-bridge that exposes `window.electronAPI`.
+- **`src/renderer`** — the React UI. `shared/hooks/app/useAppModel.ts` is the
+  central hook that composes auth, inventory, channels, watch ping, priority, and
+  stats into the app state the views render.
+
+The trickiest subsystem is the **watch engine** (auto-select / auto-switch / stall
+recovery / target suppression). It's documented in
+[`docs/watch-engine.md`](docs/watch-engine.md), with an end-to-end sequence diagram
+in [`docs/watch-flow.puml`](docs/watch-flow.puml).
+
+## Releases & updates
+
+Releases are published to GitHub Releases (Windows `.exe` + a macOS `.dmg`) and
+built by CI when a `v*` tag is pushed. The app auto-updates on Windows and offers
+two channels — **stable** and **preview** — selectable in Settings → Updates, which
+also shows the in-app release history. See [`CONTRIBUTING.md`](CONTRIBUTING.md) for
+how to cut a release.
+
+## Configuration & data
+
+Settings and stats are stored as JSON in the Electron user-data directory
+(`settings.json`, `stats.json`) and managed through the in-app Settings view.
+
+## Debug tools
+
+The Debug tab is **off by default** to keep background work minimal. Enable it in
+Settings → **Debug tools**. Debug logs are only collected while it's on; perf and
+CPU snapshots appear in the Debug snapshot.
+
+## Troubleshooting
+
+- **"Not logged in"** → use **Login with browser** in the top bar.
+- **App feels slow** → disable the Debug tab and restart.
+- **Need verbose logs** → enable Debug tools in Settings.
+
+## Tech stack
+
+Electron 42 · React 19 · Vite 7 · TypeScript · Tailwind CSS v4 · Vitest
+
+## Acknowledgements
+
+DropPilot's drop-mining approach is heavily informed by
+[**Twitch Drops Miner**](https://github.com/DevilXD/TwitchDropsMiner) by
+[DevilXD](https://github.com/DevilXD). Much of the core behavior — stream-less
+watch pings, drop/campaign validation, automatic channel switching, and
+PubSub-based status tracking — is derived from that project. Huge thanks to
+DevilXD and the Twitch Drops Miner contributors.
+
+Twitch Drops Miner is MIT-licensed (Copyright © 2024 DevilXD); its license is
+reproduced in [`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md).
+
+## License
+
+MIT — see [`LICENSE`](LICENSE).
+````
+
+- [ ] **Step 2: Verify all referenced local assets exist**
+
+Run:
+```powershell
+'docs/brand/banner-dark.svg','docs/brand/banner-light.svg','docs/brand/feat-inventory.svg','docs/brand/feat-priority.svg','docs/brand/feat-watching.svg','docs/brand/feat-autoclaim.svg','docs/brand/feat-alerts.svg','docs/brand/feat-discord.svg','docs/brand/feat-login.svg','docs/brand/feat-demo.svg','docs/screenshots/overview.png','docs/screenshots/stats.png','docs/screenshots/inventory.png','docs/screenshots/control.png' | ForEach-Object { if (Test-Path $_) { "$_ OK" } else { throw "MISSING $_" } }
+```
+Expected: one `... OK` per path; throws if any asset is missing.
+
+- [ ] **Step 3: Verify the old logo reference is gone and the new one is in**
+
+Use Grep: search `README.md` for `icons/icon.png` → expect **zero** matches. Search for `banner-dark.svg` → expect **one** match. Search for `docs/brand/feat-` → expect **eight** matches.
+
+- [ ] **Step 4: Render-check the README**
+
+Preview `README.md` (VS Code "Open Preview", or push the branch and view on GitHub — GitHub is the source of truth for `<picture>`/SVG-`<img>`/table rendering). Expected:
+  - Banner renders and swaps with the OS/GitHub light/dark theme.
+  - The four shields badges + the violet "Download for Windows" button all resolve and the button links to `/releases/latest`.
+  - The overview screenshot loads.
+  - The Features table shows two columns, each row with a violet icon + bold title + one line.
+  - The "Contents" links all jump to their sections (anchors unchanged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(readme): new SVG hero, download CTA, and icon feature grid"
+```
+
+---
+
+## Self-review (completed during planning)
+
+- **Spec coverage:** mark → Task 1; banners + `<picture>` swap → Task 2 + README Step 1; eight feature icons → Task 3; hero/badges/download CTA → README Step 1; feature table + mini-icons → README Step 1; copy pass + retained sections → README Step 1; out-of-scope (icon.png/tray, translation, source) → not touched. No gaps.
+- **Placeholder scan:** none — every SVG and the full README are spelled out.
+- **Type/name consistency:** every `docs/brand/feat-*.svg` filename created in Task 3 matches exactly the eight `<img src>` paths in README Step 1; banner filenames match the `<picture>` sources; `icons/logo.svg` is created but intentionally not yet referenced by README (it is the source for the later app-icon step).
+- **GitHub-safety:** no inline `style`/`class` anywhere; visuals are committed SVGs + shields + a table; `<picture>`/`align`/`width` are within GitHub's allowed HTML subset.

--- a/docs/superpowers/specs/2026-06-15-readme-overhaul-brand-design.md
+++ b/docs/superpowers/specs/2026-06-15-readme-overhaul-brand-design.md
@@ -1,0 +1,146 @@
+# README overhaul + brand assets — design
+
+**Date:** 2026-06-15
+**Branch:** `docs/readme-overhaul`
+**Status:** approved (brainstorm), pending implementation plan
+
+## Goal
+
+Give DropPilot a "stable" logo and a fresher, cooler-looking README. "Stable"
+means resolution-independent: one SVG source the mark is drawn from, so it stays
+crisp from a 16px tray icon to a 1024px app icon to the README header, and stays
+visually consistent everywhere. The README gets a full hero, a download CTA, and
+a feature grid, with the copy tightened.
+
+App-icon (`icon.png`) and tray-icon regeneration are **explicitly out of scope**
+for this pass — handled later as its own step. This pass produces the vector
+sources so that follow-up is a pure raster step.
+
+## The mark
+
+A water **droplet** (the "Drop") with a white **navigation arrow** inside it (the
+"Pilot" / heading). Filled execution — the most robust at tiny sizes and on any
+background, including a transparent tray.
+
+Canonical geometry (24×24 viewBox), reused verbatim everywhere:
+
+```
+droplet:  M12 2 C12 2 5 9 5 14 a7 7 0 1 0 14 0 C19 9 12 2 12 2 Z
+arrow:    M12 9 L15.5 18.5 L12 16 L8.5 18.5 Z
+```
+
+Colors (from the app's `--dp-*` tokens):
+
+| Use          | Dark                           | Light                           |
+| ------------ | ------------------------------ | ------------------------------- |
+| Droplet fill | `#a78bfa` (`--dp-accent` dark) | `#7c5fe6` (`--dp-accent` light) |
+| Arrow fill   | `#ffffff`                      | `#ffffff`                       |
+
+The arrow is a solid white fill on top of the droplet in both themes (white reads
+on both violets). No gradients, no filters — flat fills only, so it rasterizes
+cleanly later.
+
+## Wordmark
+
+"Drop" + "Pilot" as a two-tone wordmark:
+
+- "Drop" → `#e6edf3` (dark) / `#1a1c1f` (light)
+- "Pilot" → `#a78bfa` (dark) / `#7c5fe6` (light)
+- Weight 500, slight negative letter-spacing (~-0.5px). Font: the SVG bakes in a
+  generic sans (`font-family` system stack) since GitHub won't load a webfont
+  into an `<img>`-referenced SVG.
+
+## New asset files
+
+- `icons/logo.svg` — the mark only (droplet + arrow), dark-theme colors, square
+  viewBox. Single source of truth; the future app-icon/tray raster derives from
+  this.
+- `docs/brand/banner-dark.svg` and `docs/brand/banner-light.svg` — the hero
+  lockup: mark above the "DropPilot" wordmark, centered (matches the approved
+  mockup). One file per theme. `alt="DropPilot"`.
+- `docs/brand/feat-*.svg` — eight monoline feature icons (24×24, stroke
+  `#a78bfa`, `stroke-width` 2, round caps, no fill — a mid-tone violet line reads
+  on both GitHub themes). One file per feature (see grid below). Tabler-outline
+  shapes are the visual reference.
+
+## README structure
+
+Centered hero (HTML `<div align="center">`, the only HTML GitHub reliably
+renders):
+
+1. **Banner** via `<picture>` so GitHub swaps dark/light automatically:
+   ```html
+   <picture>
+     <source media="(prefers-color-scheme: dark)" srcset="docs/brand/banner-dark.svg" />
+     <img src="docs/brand/banner-light.svg" width="360" alt="DropPilot" />
+   </picture>
+   ```
+2. **Tagline** (markdown text, stays selectable/SEO): "Automate Twitch Drops —
+   quietly in the background, transparent about what it's doing."
+3. **Badges** — keep the existing shields (build, latest release, platforms,
+   license).
+4. **Download CTA** — a shields `for-the-badge` styled link to the latest
+   release, e.g. `https://img.shields.io/badge/⬇_Download_for_Windows-7c5fe6?style=for-the-badge` linking to `/releases/latest`. Looks like a button, no CSS needed.
+5. **Screenshot** — the existing `docs/screenshots/overview.png`.
+
+Then the body sections.
+
+### Features — table + mini-icons
+
+A 2-column markdown table; each cell = `<img ... width="20">` mini-icon + **bold
+title** + one line. Markdown tables and per-cell `<img>` both render on GitHub;
+the icons carry their own styling internally (so no stripped CSS). Eight
+features, 4 rows × 2:
+
+| #   | Title               | One-liner                                                        | Icon ref      |
+| --- | ------------------- | ---------------------------------------------------------------- | ------------- |
+| 1   | Live inventory      | Every drop's progress, claim status and time left, in real time. | list-check    |
+| 2   | Priority list       | Rank your games; it works the highest one it can progress now.   | arrows-sort   |
+| 3   | Hands-off watching  | Picks a stream, switches on offline, recovers on stall.          | player-play   |
+| 4   | Auto-claim          | Claims finished drops and keeps a record of everything.          | circle-check  |
+| 5   | Desktop alerts      | New drops, auto-claims, switches, drops ending, errors.          | bell          |
+| 6   | Discord / webhook   | The same alerts in Discord or any compatible webhook.            | brand-discord |
+| 7   | Browser-based login | Sign in on Twitch's own page; credentials never stored.          | browser       |
+| 8   | Demo mode           | Explore the whole UI with sample data, no account needed.        | flask         |
+
+"Stays transparent", "Debug tools", and Windows auto-update remain as prose /
+their existing sections (transparency is already carried by the tagline +
+intro). Warmup mode stays gone.
+
+### Remaining sections
+
+Keep the current set (Quick start, How it works, Releases & updates,
+Configuration & data, Debug tools, Troubleshooting, Tech stack,
+Acknowledgements, License). Light copy pass only: tighten wording, kill
+redundancy, verify facts (Electron 42 / React 19 / Vite 7 are already correct).
+The "Contents" TOC is updated if anchors change.
+
+## GitHub rendering constraints (the load-bearing decisions)
+
+- GitHub **strips `style` attributes, `class`, and `<style>`** in markdown — the
+  card aesthetic from the mockup therefore comes from **committed SVGs + a
+  markdown table**, never inline CSS.
+- `<picture>` with `prefers-color-scheme` **is** supported and gives the dark/light
+  banner swap.
+- SVG referenced via `<img src>` renders (served through GitHub's camo proxy);
+  inline `<svg>` in markdown is stripped — so all SVG lives in committed files.
+- Mini-icons must be single-color mid-tone (violet) so one file works on both
+  GitHub themes without a `<picture>` per icon.
+
+## Out of scope
+
+- Regenerating `icon.png` and the tray icons from the new mark (separate raster
+  step, later).
+- Translating the README (stays English; UI chrome i18n is unaffected).
+- Any app/source-code change — this pass touches docs + brand assets only.
+
+## Verification
+
+- `npm run format:check` passes (Prettier gates CI; run `format` on any new
+  files — note SVG/MD formatting).
+- README renders correctly on GitHub: banner swaps with theme, badges and the
+  download button resolve, screenshot loads, the feature table shows icons, all
+  internal links/anchors resolve.
+- Eyeball the banner + mark at small sizes (the scale test already validated the
+  geometry).
+- No broken relative paths to the new `docs/brand/*` assets.

--- a/icons/logo.svg
+++ b/icons/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="256" height="256" role="img" aria-label="DropPilot">
+  <path d="M12 2C12 2 5 9 5 14a7 7 0 1 0 14 0C19 9 12 2 12 2Z" fill="#a78bfa" />
+  <path d="M12 9L15.5 18.5L12 16L8.5 18.5Z" fill="#ffffff" />
+</svg>


### PR DESCRIPTION
Macht das README aktuell **und** optisch ansprechender (Inhalts-Refresh + Glow-up).

## Inhalt aktualisiert
- **Tech-Stack:** Electron 40 → **42** (Stand `package.json`).
- **Neue Features** ergänzt: **Discord/Webhook-Benachrichtigungen** (#60) und **Engine-Transparenz** (Status-Rail Standby→Scanning→Watching→Recovering→Hold, Claim-Retry-Countdown, Session-abgelaufen-Banner mit Re-Login, #61). „Alerts"-Bullet auf die Desktop-Notification-Events präzisiert.
- **Releases-Sektion:** „macOS artifacts" → „a macOS `.dmg`" (passt jetzt zu den schlanken Release-Assets aus #62).

## Optisch aufpoliert
- Zentrierter Header: Logo, Tagline, **Badges** (Build · Latest Release · Total Downloads · Platforms · License) und Download-CTA.
- **Hero-Screenshot** (`overview.png`) direkt unter dem Header; die übrigen drei Screenshots als 3-Spalten-Tabelle.
- **Inhaltsverzeichnis** ergänzt; Tech-Stack nach unten an Referenz-Position verschoben.

## Verifikation
- Alle 10 verlinkten Dateien (Logo, LICENSE, CONTRIBUTING, THIRD_PARTY_NOTICES, watch-engine/-flow, 4 Screenshots) existieren — keine toten Links.
- Badges sind dynamisch (shields.io / Actions) → veralten nicht.

🤖 Generated with [Claude Code](https://claude.com/claude-code)