### PR TITLE
feat(main): prevent multiple app instances with single-instance lock

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -15,6 +15,26 @@ import { loadStats, saveStats, bumpStats, resetStats } from "./core/stats";
 
 const isDev = !app.isPackaged;
 
+// Single-instance guard: only one DropPilot process may run at a time. A second
+// launch (double-clicking the exe while it's already in the tray, or auto-start
+// firing alongside a manual launch) fails to acquire the lock and exits before
+// doing any startup work. Electron forwards that launch to the first process via
+// the "second-instance" event, which we use to surface the running window.
+const gotSingleInstanceLock = app.requestSingleInstanceLock();
+if (!gotSingleInstanceLock) {
+  app.quit();
+} else {
+  app.on("second-instance", () => {
+    const [win] = BrowserWindow.getAllWindows();
+    if (!win) return;
+    if (win.isMinimized()) win.restore();
+    // Default close-to-tray hides the window rather than destroying it, so a
+    // running instance often has a hidden-but-alive window to reveal.
+    if (!win.isVisible()) win.show();
+    win.focus();
+  });
+}
+
 /**
  * Behavior flags read on every close/minimize event. Seeded from settings
  * at startup; refreshed whenever the IPC layer saves new settings (see
@@ -458,6 +478,9 @@ function setupAutoUpdater() {
 }
 
 app.whenReady().then(async () => {
+  // Losing instance: the lock guard above already called app.quit(); bail before
+  // creating a window or starting any Twitch/IPC services.
+  if (!gotSingleInstanceLock) return;
   const startHidden = process.argv.includes("--start-in-tray");
   // Read settings before creating the window so we can restore bounds + seed
   // behavior flags before any close/minimize event can fire.


### PR DESCRIPTION
## What

Adds an Electron single-instance lock so only one DropPilot process can run at a time. A second launch surfaces the already-running window instead of starting a duplicate process.

## Why

DropPilot defaults to close-to-tray, so the window is usually hidden-but-alive rather than closed. Without a guard, double-clicking the exe (or auto-start firing while a manual instance is already running) spins up a *second* process — two trackers, two PubSub connections, two trays competing over the same Twitch session.

## How

In `src/main/index.ts`:

- Call `app.requestSingleInstanceLock()` before startup. The losing instance calls `app.quit()` and never creates a window or starts Twitch/IPC services.
- The winning instance handles the `second-instance` event by restoring the existing window from the tray (`restore()`/`show()`) and focusing it — chosen behavior: *bring the running window to front*.
- A belt-and-suspenders early-return at the top of the `app.whenReady()` callback (`if (!gotSingleInstanceLock) return;`) guarantees a losing instance does no startup work even if `ready` still fires.

## Verification

- `npm run typecheck` (both tsconfigs): clean
- `npm run format:check` / prettier: clean
- `npm run lint`: clean for the changed file (pre-existing warnings only, in unrelated `renderer/.../watch` hooks)
- `npm test`: 514 passed

`index.ts` is main-process lifecycle wiring and isn't unit-testable (consistent with the project's pure-function-only test convention), so there's no automated test for this path.

## Reviewer notes

- **Not yet runtime-verified** end-to-end (launching the built app twice and observing the window surface). The logic is the standard documented Electron single-instance pattern.
- Applied unconditionally, including dev. `npm run dev` only ever launches one instance and vite-plugin-electron releases the lock on hot-restart; if it ever interferes, guarding with `app.isPackaged` is a one-line fallback.
- Auto-update unaffected: `quitAndInstall` exits the old process (releasing the lock) before the new one launches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
