### PR TITLE
fix(watch): keep no-farmable grace alive across transient active-drop blips

### DIFF
--- a/src/renderer/shared/hooks/watch/useStallRecovery.ts
+++ b/src/renderer/shared/hooks/watch/useStallRecovery.ts
@@ -11,6 +11,7 @@ import {
   decideIdleNoFarmable,
   decideNoProgressRecovery,
   decideWatchingNoFarmable,
+  reconcileNoFarmableOnActiveDrop,
   type NoFarmableMarker,
   type StallRecoveryAction,
   type WatchConfirmationProbe,
@@ -227,7 +228,14 @@ export function useStallRecovery({
       runActions(decision.actions);
       return;
     }
-    noFarmableDropRef.current = null;
+    // Keep the no-farmable grace alive across a transient activeDropInfo blip
+    // while the target is still unwatchable; only clear it once the target is
+    // genuinely watchable again. Prevents an oscillating active-drop signal from
+    // resetting the grace forever (engine wedged in "watching, not watchable").
+    noFarmableDropRef.current = reconcileNoFarmableOnActiveDrop(
+      noFarmableDropRef.current,
+      canWatchTarget,
+    );
     if (!activeDropInfo) {
       watchStallTrackerRef.current = null;
       watchConfirmationProbeRef.current = null;

--- a/src/renderer/shared/hooks/watch/watchStallRecovery.test.ts
+++ b/src/renderer/shared/hooks/watch/watchStallRecovery.test.ts
@@ -9,6 +9,7 @@ import {
   NO_FARMABLE_DROP_GRACE_MS,
   NO_FARMABLE_GAME_COOLDOWN_MS,
   pickStallRecoveryChannel,
+  reconcileNoFarmableOnActiveDrop,
   shouldProbeNoProgressConfirmation,
   STALL_CONFIRMATION_PROBE_COOLDOWN_MS,
   STALL_MAX_CHANNEL_RECOVERY_ATTEMPTS,
@@ -592,6 +593,49 @@ describe("decideWatchingNoFarmable", () => {
       "stop-watching",
       "dispatch-stall-stop",
     ]);
+  });
+});
+
+describe("reconcileNoFarmableOnActiveDrop (no-farmable wedge)", () => {
+  it("preserves the grace marker when an active drop blips in while the target stays unwatchable", () => {
+    const marker = { key: "Rust", sinceAt: 1 };
+    // canWatchTarget=false: a transient activeDropInfo must NOT reset the grace.
+    expect(reconcileNoFarmableOnActiveDrop(marker, false)).toBe(marker);
+  });
+
+  it("clears the marker once the target is genuinely watchable again", () => {
+    expect(reconcileNoFarmableOnActiveDrop({ key: "Rust", sinceAt: 1 }, true)).toBeNull();
+  });
+
+  it("stays null when there is no marker to preserve", () => {
+    expect(reconcileNoFarmableOnActiveDrop(null, false)).toBeNull();
+  });
+
+  it("still escalates after the grace period despite a transient active-drop blip", () => {
+    const start = 100_000;
+    // tick 1 — no active drop, target unwatchable: seed the grace marker.
+    const seeded = decideWatchingNoFarmable({
+      ...watchingBase,
+      now: start,
+      noFarmable: null,
+    }).noFarmable;
+    expect(seeded).toEqual({ key: "Rust", sinceAt: start });
+
+    // tick 2 — an active drop blips in while still unwatchable; the executor
+    // reconciles the marker here. With the fix it must be preserved, otherwise
+    // the 30s grace never completes and the engine wedges in
+    // "watching, but target not watchable".
+    const afterBlip = reconcileNoFarmableOnActiveDrop(seeded, false);
+    expect(afterBlip).toEqual({ key: "Rust", sinceAt: start });
+
+    // tick 3 — active drop gone, grace window elapsed: give-up must fire.
+    const result = decideWatchingNoFarmable({
+      ...watchingBase,
+      now: start + NO_FARMABLE_DROP_GRACE_MS + 1,
+      noFarmable: afterBlip,
+    });
+    expect(result.actions.map((a) => a.kind)).toContain("stop-watching");
+    expect(result.resetStallTracking).toBe(true);
   });
 });
 

--- a/src/renderer/shared/hooks/watch/watchStallRecovery.ts
+++ b/src/renderer/shared/hooks/watch/watchStallRecovery.ts
@@ -36,6 +36,24 @@ export type StallRecoveryAction =
 /** "Watching with no farmable drop" grace-period marker (was noFarmableDropRef). */
 export type NoFarmableMarker = { key: string; sinceAt: number };
 
+/**
+ * Recovery-branch upkeep for the no-farmable grace marker.
+ *
+ * `useStallRecovery` enters the no-progress recovery branch whenever an
+ * `activeDropInfo` is present. Clearing the no-farmable grace there is only safe
+ * when the target is genuinely watchable again (`canWatchTarget`). While the
+ * target stays unwatchable, a *transient* `activeDropInfo` blip (e.g. an
+ * upcoming/unlinked drop surfacing for a tick) must NOT reset the grace —
+ * otherwise an oscillating active-drop signal keeps restarting the
+ * `NO_FARMABLE_DROP_GRACE_MS` window and `decideWatchingNoFarmable`'s give-up
+ * path never fires, wedging the engine in "watching, but target currently not
+ * watchable".
+ */
+export const reconcileNoFarmableOnActiveDrop = (
+  marker: NoFarmableMarker | null,
+  canWatchTarget: boolean,
+): NoFarmableMarker | null => (canWatchTarget ? null : marker);
+
 export type IdleNoFarmableInput = {
   allowWatching: boolean;
   autoSelectEnabled: boolean;


### PR DESCRIPTION
## Symptom

The engine status panel could get stuck on **"Watching, but target currently not watchable"** for a very long time (observed: 1h17m) with `SUPPRESSION none`, `COOLDOWNS none`, still actively "Watching", and a **frozen** no-progress tracker showing `0 recovery attempts`. A full app refresh cleared it — i.e. it was a wedged runtime state, not expected parking.

## Root cause

Watchability is decided by drop **state**, not channels, so a target with only claimable/blocked/upcoming drops is correctly `canWatchTarget = false`. When that happens while watching, `decideWatchingNoFarmable` is supposed to wait out `NO_FARMABLE_DROP_GRACE_MS` (30s) and then give up: cooldown + retarget + stop + stall-stop. That pure logic is correct and already tested.

The bug is in the executor `useStallRecovery`: it cleared the no-farmable grace marker (`noFarmableDropRef.current = null`) on **every** pass through the no-progress recovery branch — i.e. whenever `activeDropInfo` was momentarily present. If the active-drop selection oscillates (e.g. an upcoming/unlinked drop surfacing for a tick while `canWatchTarget` stays false), the marker is reset on each blip, the 30s grace never completes, the give-up path never fires, and the stale stall tracker keeps showing `0 attempts`.

This matches all observed symptoms: no give-up, no cooldown, no suppression, frozen tracker.

## Fix

Preserve the grace marker across a transient `activeDropInfo` while the target stays unwatchable; clear it only once the target is genuinely watchable again (`canWatchTarget === true`). Extracted as the pure `reconcileNoFarmableOnActiveDrop(marker, canWatchTarget)` and wired into the executor in place of the unconditional reset.

Entry condition of the no-farmable branch is intentionally left on `!activeDropInfo` (not `!canWatchTarget`) so the existing channel-switch recovery — for the case where watchable drops exist but not on the current channel — is preserved.

## Tests

TDD: added a failing regression first, then the fix.

- `reconcileNoFarmableOnActiveDrop` units: preserve while unwatchable, clear when watchable, null-safe.
- End-to-end flicker regression: seed grace → active-drop blip (marker must survive) → grace elapsed → give-up (`stop-watching` + `resetStallTracking`) fires.

`npm test` (524 passing), `npm run typecheck` (both tsconfigs), prettier + eslint on changed files: all clean.

## Notes

Found via a user-reported screenshot. Workaround until merged: stop/restart watching (or toggle the master switch) re-initializes the refs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
